### PR TITLE
Update Neovim config & make Checkstyle and Java Formatter be consistent.

### DIFF
--- a/.lazy.lua
+++ b/.lazy.lua
@@ -1,0 +1,73 @@
+local format =
+	"[%tRROR] %f:%l:%c: %m, [%tRROR] %f:%l: %m, [%tARN] %f:%l:%c: %m, [%tARN] %f:%l: %m, [%tNFO] %f:%l:%c: %m, [%tNFO] %f:%l: %m"
+
+return {
+	{
+		"nvimtools/none-ls.nvim",
+		event = "LazyFile",
+		dependencies = { "mason.nvim" },
+		config = function()
+			local null_ls = require("null-ls")
+
+			-- Setup null-ls with full override (ignores LazyVim defaults)
+			null_ls.setup({
+				debug = true,
+				root_dir = require("null-ls.utils").root_pattern(".null-ls-root", ".neoconf.json", "Makefile", ".git"),
+				sources = {
+					null_ls.builtins.formatting.fish_indent,
+					null_ls.builtins.diagnostics.fish,
+					null_ls.builtins.formatting.stylua,
+					null_ls.builtins.formatting.shfmt,
+					null_ls.builtins.diagnostics.checkstyle.with({
+						args = { "-f", "sarif", "$FILENAME" },
+						parser = require("lint.parser").from_errorformat(format, {
+							source = "checkstyle",
+						}),
+						extra_args = { "-c", "./checkstyle.xml" },
+					}),
+				},
+			})
+
+			-- Register with LazyVim for formatting
+			LazyVim.format.register({
+				name = "none-ls.nvim",
+				priority = 300, -- Higher priority than built-in formatter
+				primary = true,
+				format = function(buf)
+					return LazyVim.lsp.format({
+						bufnr = buf,
+						filter = function(client)
+							return client.name == "null-ls"
+						end,
+					})
+				end,
+				sources = function(buf)
+					local ret = require("null-ls.sources").get_available(vim.bo[buf].filetype, "NULL_LS_FORMATTING")
+						or {}
+					return vim.tbl_map(function(source)
+						return source.name
+					end, ret)
+				end,
+			})
+		end,
+	},
+	{
+		"mfussenegger/nvim-jdtls",
+		config = function()
+			local jdtls = require("jdtls")
+
+			jdtls.start_or_attach({
+				cmd = { "jdtls" },
+				settings = {
+					java = {
+						format = {
+							settings = {
+								url = vim.fn.expand("./java-formatter.xml"),
+							},
+						},
+					},
+				},
+			})
+		end,
+	},
+}

--- a/.nvim.lua
+++ b/.nvim.lua
@@ -4,39 +4,23 @@ vim.o.expandtab = true -- Pressing the TAB key will insert spaces instead of a T
 vim.o.softtabstop = 4 -- Number of spaces inserted instead of a TAB character
 vim.o.shiftwidth = 4 -- Number of spaces inserted when indenting
 
--- Ensure jdtls uses 4 spaces for indentation as well as format with the current formatter file.
-local config = {
-	settings = {
-		java = {
-			format = {
-				settings = {
-					url = "./java-formatter.xml",
-					tabSize = 4,
-					indentationSize = 4,
-					insertSpaces = true,
-				},
-			},
-		},
-	},
-}
-
--- Apply settings only if jdtls is running
-if vim.lsp.get_active_clients({ name = "jdtls" }) then
-	require("lspconfig").jdtls.setup(config)
-end
-
--- Use local checkstyle.xml
-local none_ls = require("lazy.core.config").spec.plugins["nvimtools/none-ls.nvim"]
-
-if none_ls then
-	none_ls.opts = function(_, opts)
-		local nls = require("null-ls")
-
-		-- Override sources to use local checkstyle.xml
-		opts.sources = vim.list_extend(opts.sources or {}, {
-			nls.builtins.diagnostics.checkstyle.with({
-				extra_args = { "-c", "./checkstyle.xml" }, -- Override to use local checkstyle.xml
-			}),
-		})
-	end
-end
+-- -- Ensure jdtls uses 4 spaces for indentation as well as format with the current formatter file.
+-- local config = {
+-- 	settings = {
+-- 		java = {
+-- 			format = {
+-- 				settings = {
+-- 					url = "./java-formatter.xml",
+-- 					tabSize = 4,
+-- 					indentationSize = 4,
+-- 					insertSpaces = true,
+-- 				},
+-- 			},
+-- 		},
+-- 	},
+-- }
+--
+-- -- Apply settings only if jdtls is running
+-- if vim.lsp.get_active_clients({ name = "jdtls" }) then
+-- 	require("lspconfig").jdtls.setup(config)
+-- end

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -75,7 +75,7 @@ https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
     <module name="FileLength" />
     <module name="LineLength">
         <property name="fileExtensions" value="java" />
-        <property name="max" value="205" />
+        <property name="max" value="200" />
     </module>
 
     <!-- Checks for whitespace                               -->

--- a/java-formatter.xml
+++ b/java-formatter.xml
@@ -174,7 +174,7 @@
             value="insert" />
         <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped"
             value="true" />
-        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="150" />
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80" />
         <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true" />
         <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line"
             value="one_line_never" />
@@ -805,7 +805,7 @@
             value="do not insert" />
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true" />
         <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1" />
-        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="140" />
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="200" />
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation"
             value="do not insert" />
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch"

--- a/src/main/java/com/patina/codebloom/api/submission/SubmissionController.java
+++ b/src/main/java/com/patina/codebloom/api/submission/SubmissionController.java
@@ -69,7 +69,8 @@ public class SubmissionController {
     private final POTDRepository potdRepository;
 
     /**
-     * This checks if the different is 24 hours, instead of checking whether they are actually part of the "same day".
+     * This checks if the different is 24 hours, instead of checking whether they
+     * are actually part of the "same day".
      */
     private boolean isSameDay(final LocalDateTime createdAt) {
         LocalDateTime now = LocalDateTime.now();
@@ -119,7 +120,7 @@ public class SubmissionController {
                     """, responses = {
             @ApiResponse(responseCode = "401", description = "Not authenticated", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class))),
             @ApiResponse(responseCode = "200", description = "Name has been set successfully", content = @Content(schema = @Schema(implementation = UnsafeEmptySuccessResponse.class))),
-            @ApiResponse(responseCode = "409", description = "Attempt to set name that has already been set", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Attempt to set name that's already been set", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class))),
             @ApiResponse(responseCode = "400", description = "Invalid username", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class))) })
     @PostMapping("/set")
     public ResponseEntity<ApiResponder<Void>> setLeetcodeUsername(final HttpServletRequest request,


### PR DESCRIPTION
The biggest problem with the old .nvim.lua file is that it does not work for lazy.nvim plugins whatsoever. It was essentially a race condition hack that would fail half of the time. However, this should no longer be an issue as the .lazy.lua file will override any plugins that have been set inside of the base neovim config. This will now properly apply the proper plugin overrides required to use Checkstyle and Java formatter within Neovim. .nvim.lua still enforces the tab size to be 4 spaces. Improved Checkstyle and Java Formatter config files to be more consistent.