### PR TITLE
Fixed bug on submission user fetch query

### DIFF
--- a/js/src/app/dashboard/_components/RecentSubmissions/RecentSubmissions.tsx
+++ b/js/src/app/dashboard/_components/RecentSubmissions/RecentSubmissions.tsx
@@ -4,7 +4,7 @@ import { Badge, Box, Button, Card, Flex, Text, Title } from "@mantine/core";
 import { Link } from "react-router-dom";
 
 export default function RecentSubmissions({ userId }: { userId: string }) {
-  const { data, status } = useUserSubmissionsQuery({ userId, pageSize: 5 });
+  const { data, status } = useUserSubmissionsQuery({ userId });
 
   if (status === "pending") {
     return <RecentSubmissionsSkeleton />;
@@ -47,6 +47,7 @@ export default function RecentSubmissions({ userId }: { userId: string }) {
   }
 
   const questions = data.data.data;
+  const dashboardQuestions = questions.slice(0, 5);
 
   if (!questions.length) {
     return (
@@ -76,7 +77,7 @@ export default function RecentSubmissions({ userId }: { userId: string }) {
         </Button>
       </Flex>
 
-      {questions.map((q, idx) => {
+      {dashboardQuestions.map((q, idx) => {
         const badgeColor = (() => {
           if (q.questionDifficulty === "Easy") {
             return undefined;

--- a/js/src/lib/api/queries/user/index.ts
+++ b/js/src/lib/api/queries/user/index.ts
@@ -25,12 +25,10 @@ export const useUserSubmissionsQuery = ({
   userId,
   initialPage = 1,
   tieToUrl = false,
-  pageSize = 20,
 }: {
   userId?: string;
   initialPage?: number;
   tieToUrl?: boolean;
-  pageSize?: number;
 }) => {
   const [page, setPage] = useURLState("page", initialPage, tieToUrl);
   const [searchQuery, setSearchQuery, debouncedQuery] = useURLState(
@@ -40,6 +38,7 @@ export const useUserSubmissionsQuery = ({
     true,
     500,
   );
+  const pageSize = 20;
 
   const goBack = useCallback(() => {
     setPage((old) => Math.max(old - 1, 0));


### PR DESCRIPTION
Changed logic to hard fetch 20 questions, but we only use the first 5 for the dashboard page. Now we don't have to keep refetching data btwn the dashboard and viewing all submissions