### PR TITLE
Enabled asset caching on the server (DESC)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,3 +30,6 @@ email.port=${EMAIL_PORT}
 email.type=${EMAIL_TYPE}
 email.username=${EMAIL_USERNAME}
 email.password=${EMAIL_PASSWORD}
+
+spring.web.resources.cache.cachecontrol.max-age=30m
+spring.web.resources.cache.cachecontrol.public=true


### PR DESCRIPTION
This will stop the bug where the logo image is changed every single time on the frontend. The TTL is set relatively low at 30m so that if we decide to change the image or logo, it will expire relatively soon. This won't affect .js,.css,.html or any other files from Vite because those files have hashes and change everytime we re-deploy.