### PR TITLE
Fix useUrlState bug with page in leaderboard query (DESC)

### DIFF
--- a/js/src/lib/api/queries/leaderboard/index.ts
+++ b/js/src/lib/api/queries/leaderboard/index.ts
@@ -9,7 +9,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 
 /**
  * Fetch the users on the current leaderboard. This is a super query
@@ -26,6 +26,9 @@ export const useCurrentLeaderboardUsersQuery = ({
 }) => {
   const [page, setPage] = useURLState("page", initialPage, tieToUrl);
 
+  /**
+   * We wrap _setSearchQuery with a setSearchQuery because we need to run a side effect anytime we update the query.
+   */
   const [searchQuery, _setSearchQuery, debouncedQuery] = useURLState(
     "query",
     "",
@@ -50,6 +53,10 @@ export const useCurrentLeaderboardUsersQuery = ({
     [setPage],
   );
 
+  /**
+   * Abstracted function so that we can also reset the page back to 1 whenever we update the query.
+   * TODO - Move these side effects within the useURLState function, which will make it easier to deal with.
+   */
   const setSearchQuery = useCallback(
     (query: string) => {
       _setSearchQuery(query);

--- a/js/src/lib/api/queries/leaderboard/index.ts
+++ b/js/src/lib/api/queries/leaderboard/index.ts
@@ -25,7 +25,8 @@ export const useCurrentLeaderboardUsersQuery = ({
   tieToUrl?: boolean;
 }) => {
   const [page, setPage] = useURLState("page", initialPage, tieToUrl);
-  const [searchQuery, setSearchQuery, debouncedQuery] = useURLState(
+
+  const [searchQuery, _setSearchQuery, debouncedQuery] = useURLState(
     "query",
     "",
     tieToUrl,
@@ -33,10 +34,6 @@ export const useCurrentLeaderboardUsersQuery = ({
     500,
   );
   const [patina, setPatina] = useURLState("patina", false, true, true, 100);
-
-  useEffect(() => {
-    setPage(1);
-  }, [patina, setPage]);
 
   const goBack = useCallback(() => {
     setPage((old) => Math.max(old - 1, 0));
@@ -52,13 +49,19 @@ export const useCurrentLeaderboardUsersQuery = ({
     },
     [setPage],
   );
-  useEffect(() => {
-    goTo(1);
-  }, [searchQuery, goTo]);
+
+  const setSearchQuery = useCallback(
+    (query: string) => {
+      _setSearchQuery(query);
+      goTo(1);
+    },
+    [_setSearchQuery, goTo],
+  );
 
   const togglePatina = useCallback(() => {
     setPatina((prev) => !prev);
-  }, [setPatina]);
+    goTo(1);
+  }, [setPatina, goTo]);
 
   const query = useQuery({
     queryKey: ["leaderboard", "users", page, pageSize, debouncedQuery, patina],

--- a/js/src/lib/hooks/useUrlState.ts
+++ b/js/src/lib/hooks/useUrlState.ts
@@ -20,14 +20,14 @@ export function useURLState<T>(
   resetOnDefault = true,
   debounce = 0,
 ) {
-  const [initial, setInitial] = useState(false);
+  const [initial, setInitial] = useState(true);
   const [value, setValue] = useState<T>(defaultValue);
   const [debouncedValue] = useDebouncedValue<T>(value, debounce);
   const [searchParams, setSearchParams] = useSearchParams();
 
   // On initial mount, update the state with the URL params. This hook will not run if the hook is not enabled or the initial value has already been provided.
   useEffect(() => {
-    if (!enabled || initial) {
+    if (!enabled || !initial) {
       return;
     }
 
@@ -36,19 +36,23 @@ export function useURLState<T>(
     // No value found in the URL.
     if (param == null) {
       setValue(defaultValue);
-      setInitial(true);
+      setInitial(false);
       return;
     }
 
     const val = coerce(param, defaultValue);
     // If coercion of type fails, it will return Symbol.
     setValue(typeof val === "symbol" ? defaultValue : val);
-    setInitial(true);
+    setInitial(false);
   }, [defaultValue, name, searchParams, enabled, initial]);
 
   // Update the URL with the new state, only if the initial value hasn't been set already and if the hook is enabled.
   useEffect(() => {
-    if (!enabled || !initial) {
+    if (!enabled || initial) {
+      return;
+    }
+
+    if (debouncedValue != value) {
       return;
     }
 


### PR DESCRIPTION
The problem was that the useEffect to reset the page to page 1 when patina or query changes would cause the page state to break because it would be toggled back to page 1 before the state would finish running. The better solution would be to reset the page whenever the actual functions to update the patina filter or updagte query actually runs, which will only run when invoked, not on render.