### PR TITLE
Fix waterfalls

### DIFF
--- a/js/src/app/_component/AboutUs.tsx
+++ b/js/src/app/_component/AboutUs.tsx
@@ -1,7 +1,9 @@
 import MiniLeaderboard from "@/app/_component/MiniLeaderboard";
 import MiniLeaderboardMobile from "@/app/_component/MiniLeaderboardMobile";
 import OurFeatures from "@/app/_component/OurFeatures";
+import LeaderboardMetadata from "@/app/leaderboard/_components/LeaderboardMetadata/LeaderboardMetadata";
 import {
+  Box,
   Button,
   Center,
   Container,
@@ -63,7 +65,10 @@ export default function AboutUs() {
           direction={"column"}
           w={"50%"}
         >
-          <MiniLeaderboard />
+          <Box pos={"relative"} p={"xs"}>
+            <LeaderboardMetadata showClock />
+            <MiniLeaderboard />
+          </Box>
         </Flex>
       </Flex>
       <Flex h={"80vh"} w={"100vw"} hiddenFrom="lg">

--- a/js/src/app/_component/AboutUs.tsx
+++ b/js/src/app/_component/AboutUs.tsx
@@ -96,6 +96,7 @@ export default function AboutUs() {
         </Stack>
       </Flex>
       <Container hiddenFrom={"lg"}>
+        <LeaderboardMetadata showClock />
         <MiniLeaderboardMobile />
       </Container>
       <div ref={targetSectionRef} style={{ padding: "2rem" }}>

--- a/js/src/app/_component/MiniLeaderboard.tsx
+++ b/js/src/app/_component/MiniLeaderboard.tsx
@@ -1,5 +1,4 @@
 import MiniLeaderboardSkeleton from "@/app/_component/skeletons/MiniLeaderboardSkeleton";
-import LeaderboardMetadata from "@/app/leaderboard/_components/LeaderboardMetadata/LeaderboardMetadata";
 import LeaderboardCard from "@/components/ui/LeaderboardCard";
 import Toast from "@/components/ui/toast/Toast";
 import { useCurrentLeaderboardUsersQuery } from "@/lib/api/queries/leaderboard";
@@ -42,8 +41,7 @@ export default function MiniLeaderboardDesktop() {
   const [first, second, third] = leaderboardData.data;
 
   return (
-    <div style={{ padding: "1rem", position: "relative" }}>
-      <LeaderboardMetadata showClock />
+    <>
       <SegmentedControl
         value={patina ? "patina" : "all"}
         w={"100%"}
@@ -171,6 +169,6 @@ export default function MiniLeaderboardDesktop() {
       >
         View All
       </Button>
-    </div>
+    </>
   );
 }

--- a/js/src/app/_component/MiniLeaderboardMobile.tsx
+++ b/js/src/app/_component/MiniLeaderboardMobile.tsx
@@ -1,5 +1,4 @@
 import MiniLeaderboardMobileSkeleton from "@/app/_component/skeletons/MiniLeaderboardMobileSkeleton";
-import LeaderboardMetadata from "@/app/leaderboard/_components/LeaderboardMetadata/LeaderboardMetadata";
 import LeaderboardCard from "@/components/ui/LeaderboardCard";
 import Toast from "@/components/ui/toast/Toast";
 import { useCurrentLeaderboardUsersQuery } from "@/lib/api/queries/leaderboard";
@@ -43,7 +42,6 @@ export default function MiniLeaderboardMobile() {
 
   return (
     <>
-      <LeaderboardMetadata showClock />
       <SegmentedControl
         value={patina ? "patina" : "all"}
         w={"100%"}

--- a/js/src/app/_component/skeletons/MiniLeaderboardMobileSkeleton.tsx
+++ b/js/src/app/_component/skeletons/MiniLeaderboardMobileSkeleton.tsx
@@ -1,19 +1,8 @@
-import { Center, Skeleton, Table, Title } from "@mantine/core";
+import { Center, Skeleton, Table } from "@mantine/core";
 
 export default function MiniLeaderboardMobileSkeleton() {
   return (
     <>
-      <Center>
-        <Title
-          style={{
-            fontSize: "1rem",
-            fontWeight: "bold",
-            marginBottom: "1rem",
-          }}
-        >
-          <Skeleton visible>Really long tVal name</Skeleton>
-        </Title>
-      </Center>
       <Center mb="md">
         <Skeleton visible width="100%" height="36px">
           <div style={{ width: "100%", height: "36px" }} />

--- a/js/src/app/_component/skeletons/MiniLeaderboardSkeleton.tsx
+++ b/js/src/app/_component/skeletons/MiniLeaderboardSkeleton.tsx
@@ -1,21 +1,8 @@
-import { Card, Center, Skeleton, Table, Title } from "@mantine/core";
+import { Box, Card, Center, Skeleton, Table } from "@mantine/core";
 
 export default function MiniLeaderboardSkeleton() {
   return (
-    <div style={{ padding: "1rem" }}>
-      <Center>
-        <Title
-          order={3}
-          style={{
-            fontSize: "1rem",
-            fontWeight: "bold",
-            marginBottom: "1rem",
-          }}
-          className="text-center sm:text-lg"
-        >
-          <Skeleton visible>Really long tVal name</Skeleton>
-        </Title>
-      </Center>
+    <Box pos={"relative"} p={"xs"}>
       <Center mb="md">
         <Skeleton visible width="100%" height="36px">
           <div style={{ width: "100%", height: "36px" }} />
@@ -85,6 +72,6 @@ export default function MiniLeaderboardSkeleton() {
           <div style={{ width: "100%", height: "36px" }} />
         </Skeleton>
       </Center>
-    </div>
+    </Box>
   );
 }

--- a/js/src/app/leaderboard/Leaderboard.page.tsx
+++ b/js/src/app/leaderboard/Leaderboard.page.tsx
@@ -1,13 +1,18 @@
 import Leaderboard from "@/app/leaderboard/_components/Leaderboard";
+import LeaderboardMetadata from "@/app/leaderboard/_components/LeaderboardMetadata/LeaderboardMetadata";
 import { Footer } from "@/components/ui/footer/Footer";
 import Header from "@/components/ui/header/Header";
+import { Box } from "@mantine/core";
 
 export default function LeaderboardPage() {
   return (
     <div className="flex flex-col min-h-screen">
       <Header />
       <div className="flex-grow">
-        <Leaderboard />
+        <Box p={"lg"}>
+          <LeaderboardMetadata showClock />
+          <Leaderboard />
+        </Box>
       </div>
       <Footer />
     </div>

--- a/js/src/app/leaderboard/_components/Leaderboard.tsx
+++ b/js/src/app/leaderboard/_components/Leaderboard.tsx
@@ -54,8 +54,7 @@ export default function LeaderboardIndex() {
   const [first, second, third] = pageData.data;
 
   return (
-    <div style={{ padding: "1rem" }}>
-      <LeaderboardMetadata showClock />
+    <>
       <div
         className="flex flex-col sm:flex-row items-center sm:items-end justify-center gap-4"
         style={{ marginBottom: "2rem" }}
@@ -207,6 +206,6 @@ export default function LeaderboardIndex() {
           </Button>
         </Flex>
       </Center>
-    </div>
+    </>
   );
 }

--- a/js/src/app/leaderboard/_components/Leaderboard.tsx
+++ b/js/src/app/leaderboard/_components/Leaderboard.tsx
@@ -1,4 +1,3 @@
-import LeaderboardMetadata from "@/app/leaderboard/_components/LeaderboardMetadata/LeaderboardMetadata";
 import LeaderboardSkeleton from "@/app/leaderboard/_components/LeaderboardSkeleton";
 import FilterDropdown from "@/components/ui/dropdown/FilterDropdown";
 import FilterDropdownItem from "@/components/ui/dropdown/FilterDropdownItem";

--- a/js/src/app/leaderboard/_components/LeaderboardSkeleton.tsx
+++ b/js/src/app/leaderboard/_components/LeaderboardSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Skeleton, Table, Title } from "@mantine/core";
+import { Center, Skeleton, Table } from "@mantine/core";
 
 /**
  * @todo - Could possibly scan the URL for page number and define different skeletons based off of that.

--- a/js/src/app/leaderboard/_components/LeaderboardSkeleton.tsx
+++ b/js/src/app/leaderboard/_components/LeaderboardSkeleton.tsx
@@ -1,28 +1,12 @@
-import { Center, Skeleton, Table, Title } from "@mantine/core";
+import { Box, Center, Skeleton, Table, Title } from "@mantine/core";
 
 /**
  * @todo - Could possibly scan the URL for page number and define different skeletons based off of that.
  */
 export default function LeaderboardSkeleton() {
   return (
-    <div style={{ padding: "1rem" }}>
-      <Center>
-        <Title
-          order={3}
-          style={{
-            fontSize: "1rem",
-            fontWeight: "bold",
-            marginBottom: "1rem",
-          }}
-          className="text-center sm:text-lg"
-        >
-          <Skeleton visible>Really long tVal name</Skeleton>
-        </Title>
-      </Center>
-      <div
-        className="flex flex-col sm:flex-row items-center sm:items-end justify-center gap-4"
-        style={{ marginBottom: "2rem" }}
-      >
+    <>
+      <div className="flex flex-col sm:flex-row items-center sm:items-end justify-center gap-4">
         {Array(3)
           .fill(0)
           .map((_, index) => {
@@ -42,6 +26,7 @@ export default function LeaderboardSkeleton() {
           display: "flex",
           justifyContent: "flex-end",
           marginBottom: "1rem",
+          paddingTop: "2rem",
         }}
       >
         <Skeleton visible width={"100px"} height={"36px"}>
@@ -85,6 +70,6 @@ export default function LeaderboardSkeleton() {
             ))}
         </Table.Tbody>
       </Table>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
The problem with the leaderboard items is that the entire list loads, and then when the list is loaded, it then queries to load the metadata. Here is an example:

```tsx
export default function leaderboardList() {
  // Example query
  const { data, status } = fetchLeaderboardListQuery();

  if (status === "pending") {
    return <Loader />;
  }

  if (status === "error") {
    return <div>Sorry, something went wrong.</div>;
  }

  const { data: listData } = data;

  return (
    <div className="flex flex-row justify-center gap-4">
      {/* This metadata will not start loading until we finish loading the list. */}
      <LeaderboardMetadata />
      {listData.map((player) => (
        <div>
          <div>{player.name}</div>
          ...
        </div>
      ))}
    </div>
  );
}
```

This should be resolved now, and the skeletons should reflect these changes.