### PR TITLE
Update the Page object in the backend to use items instead of data.

### DIFF
--- a/js/src/app/_component/MiniLeaderboard.tsx
+++ b/js/src/app/_component/MiniLeaderboard.tsx
@@ -34,11 +34,11 @@ export default function MiniLeaderboardDesktop() {
 
   const leaderboardData = data.payload;
 
-  if (leaderboardData.data.length == 0) {
+  if (leaderboardData.items.length == 0) {
     return <p>Sorry, there are no users to display.</p>;
   }
 
-  const [first, second, third] = leaderboardData.data;
+  const [first, second, third] = leaderboardData.items;
 
   return (
     <>
@@ -102,7 +102,7 @@ export default function MiniLeaderboardDesktop() {
             />
           )}
         </div>
-        {leaderboardData.data.length > 3 && (
+        {leaderboardData.items.length > 3 && (
           <Table horizontalSpacing="xl">
             <Table.Thead>
               <Table.Tr>
@@ -112,7 +112,7 @@ export default function MiniLeaderboardDesktop() {
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
-              {leaderboardData.data.map((entry, index) => {
+              {leaderboardData.items.map((entry, index) => {
                 if ([0, 1, 2].includes(index)) return null;
                 return (
                   <Table.Tr key={index}>

--- a/js/src/app/_component/MiniLeaderboardMobile.tsx
+++ b/js/src/app/_component/MiniLeaderboardMobile.tsx
@@ -34,11 +34,11 @@ export default function MiniLeaderboardMobile() {
 
   const leaderboardData = data.payload;
 
-  if (leaderboardData.data.length == 0) {
+  if (leaderboardData.items.length == 0) {
     return <p>Sorry, there are no users to display.</p>;
   }
 
-  const [first, second, third] = leaderboardData.data;
+  const [first, second, third] = leaderboardData.items;
 
   return (
     <>
@@ -99,7 +99,7 @@ export default function MiniLeaderboardMobile() {
             />
           )}
         </div>
-        {leaderboardData.data.length > 3 && (
+        {leaderboardData.items.length > 3 && (
           <Table>
             <Table.Thead>
               <Table.Tr>
@@ -109,7 +109,7 @@ export default function MiniLeaderboardMobile() {
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
-              {leaderboardData.data.map((entry, index) => {
+              {leaderboardData.items.map((entry, index) => {
                 if ([0, 1, 2].includes(index)) return null;
                 return (
                   <Table.Tr key={entry.discordName}>

--- a/js/src/app/admin/_components/UserAdminList.tsx
+++ b/js/src/app/admin/_components/UserAdminList.tsx
@@ -111,7 +111,7 @@ export default function UserAdminList() {
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
-            {pageData.data.length == 0 && (
+            {pageData.items.length == 0 && (
               <Table.Tr>
                 <Table.Td colSpan={100}>
                   <Text fw={500} ta="center">
@@ -120,7 +120,7 @@ export default function UserAdminList() {
                 </Table.Td>
               </Table.Tr>
             )}
-            {pageData.data.map((user, index) => {
+            {pageData.items.map((user, index) => {
               const adminBadgeColor = (() => {
                 if (user.admin) {
                   return undefined;

--- a/js/src/app/dashboard/_components/DashboardLeaderboard/DashboardLeaderboard.tsx
+++ b/js/src/app/dashboard/_components/DashboardLeaderboard/DashboardLeaderboard.tsx
@@ -77,7 +77,7 @@ export default function LeaderboardForDashboard({
 
   const leaderboardData = data.payload;
 
-  if (leaderboardData.data.length == 0) {
+  if (leaderboardData.items.length == 0) {
     return (
       <Card withBorder padding={"md"} radius={"md"} miw={"31vw"} mih={"63vh"}>
         <Flex
@@ -96,7 +96,7 @@ export default function LeaderboardForDashboard({
     );
   }
 
-  const inTop5 = !!leaderboardData.data.find((u) => u.id === userId);
+  const inTop5 = !!leaderboardData.items.find((u) => u.id === userId);
 
   return (
     <Card withBorder padding={"md"} radius={"md"} miw={"31vw"} mih={"63vh"}>
@@ -136,7 +136,7 @@ export default function LeaderboardForDashboard({
             radius={"md"}
           />
         )}
-        {leaderboardData.data.map((user, idx) => {
+        {leaderboardData.items.map((user, idx) => {
           const isMe = user.id === userId;
 
           const borderColor = (() => {

--- a/js/src/app/dashboard/_components/RecentSubmissions/RecentSubmissions.tsx
+++ b/js/src/app/dashboard/_components/RecentSubmissions/RecentSubmissions.tsx
@@ -55,7 +55,7 @@ export default function RecentSubmissions({ userId }: { userId: string }) {
     );
   }
 
-  const questions = data.payload.data;
+  const questions = data.payload.items;
   const dashboardQuestions = questions.slice(0, 5);
 
   if (!questions.length) {

--- a/js/src/app/leaderboard/_components/Leaderboard.tsx
+++ b/js/src/app/leaderboard/_components/Leaderboard.tsx
@@ -50,7 +50,7 @@ export default function LeaderboardIndex() {
   }
 
   const pageData = data.payload;
-  const [first, second, third] = pageData.data;
+  const [first, second, third] = pageData.items;
 
   return (
     <>
@@ -132,7 +132,7 @@ export default function LeaderboardIndex() {
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
-            {pageData.data.map((entry, index) => {
+            {pageData.items.map((entry, index) => {
               if (page === 1 && !debouncedQuery && [0, 1, 2].includes(index))
                 return null;
               return (

--- a/js/src/app/user/[userId]/_components/UserSubmissions/UserSubmissions.tsx
+++ b/js/src/app/user/[userId]/_components/UserSubmissions/UserSubmissions.tsx
@@ -79,7 +79,7 @@ export default function UserSubmissions({ userId }: { userId?: string }) {
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
-            {pageData.data.length == 0 && (
+            {pageData.items.length == 0 && (
               <Table.Tr>
                 <Table.Td colSpan={100}>
                   <Text fw={500} ta="center">
@@ -88,7 +88,7 @@ export default function UserSubmissions({ userId }: { userId?: string }) {
                 </Table.Td>
               </Table.Tr>
             )}
-            {pageData.data.map((submission, index) => {
+            {pageData.items.map((submission, index) => {
               const badgeDifficultyColor = (() => {
                 if (submission.questionDifficulty === "Easy") {
                   return undefined;
@@ -152,8 +152,8 @@ export default function UserSubmissions({ userId }: { userId?: string }) {
               );
             })}
             {/* Render empty values to fill up page and avoid content shifting.*/}
-            {pageData.data.length < pageData.pageSize &&
-              Array(pageData.pageSize - pageData.data.length)
+            {pageData.items.length < pageData.pageSize &&
+              Array(pageData.pageSize - pageData.items.length)
                 .fill(0)
                 .map((_, idx) => (
                   <Table.Tr key={idx} opacity={0}>

--- a/js/src/lib/api/common/page.ts
+++ b/js/src/lib/api/common/page.ts
@@ -1,6 +1,6 @@
 export type Page<T> = {
   hasNextPage: boolean;
-  data: T;
+  items: T;
   pages: number;
   pageSize: number;
 };

--- a/js/src/lib/api/queries/admin/index.ts
+++ b/js/src/lib/api/queries/admin/index.ts
@@ -29,7 +29,7 @@ export const useToggleAdminMutation = () => {
       }
 
       // Find the user and insert the new admin status to it's object.
-      const newUsers = previousApiResponse.payload.data.map((user) =>
+      const newUsers = previousApiResponse.payload.items.map((user) =>
         user.id === userId ? { ...user, admin: toggleTo } : user,
       ) as User[];
 

--- a/src/main/java/com/patina/codebloom/common/page/Page.java
+++ b/src/main/java/com/patina/codebloom/common/page/Page.java
@@ -2,14 +2,14 @@ package com.patina.codebloom.common.page;
 
 public class Page<T> {
     private boolean hasNextPage;
-    private T data;
+    private T items;
     private int pages;
 
     private int pageSize;
 
-    public Page(final boolean hasNextPage, final T data, final int pages, final int pageSize) {
+    public Page(final boolean hasNextPage, final T items, final int pages, final int pageSize) {
         this.hasNextPage = hasNextPage;
-        this.data = data;
+        this.items = items;
         this.pages = pages;
         this.pageSize = pageSize;
     }
@@ -22,12 +22,12 @@ public class Page<T> {
         this.hasNextPage = hasNextPage;
     }
 
-    public T getData() {
-        return data;
+    public T getItems() {
+        return items;
     }
 
-    public void setData(final T data) {
-        this.data = data;
+    public void setItems(final T items) {
+        this.items = items;
     }
 
     public int getPages() {


### PR DESCRIPTION
This is similar to this PR #175: **Update the ApiResponder object in the backend to use payload instead of data**

The `data` attribute on the `Page` DTO was too confusing when chained with React Query and `ApiResponder`(backend)/`ApiResponse`(client). So, as a result, it has now been renamed to `items` to increase the clarity of what the utility of the method is.