### PR TITLE
Modified ApiResponse object

### DIFF
--- a/js/src/lib/api/common/apiResponse.ts
+++ b/js/src/lib/api/common/apiResponse.ts
@@ -30,4 +30,4 @@ type ApiError = Prettify<{
  * const todo = json.payload; // no error, type of Todo.
  * ```
  */
-export type ApiResponse<T> = ApiSuccess<T> | ApiError;
+export type UnknownApiResponse<T> = ApiSuccess<T> | ApiError;

--- a/js/src/lib/api/common/apiResponse.ts
+++ b/js/src/lib/api/common/apiResponse.ts
@@ -1,12 +1,12 @@
 import { Prettify } from "@/lib/prettify";
 
-type SuccessType<T> = Prettify<{
+type ApiSuccess<T> = Prettify<{
   success: true;
   message: string;
   payload: T;
 }>;
 
-type ErrorType = Prettify<{
+type ApiError = Prettify<{
   success: false;
   message: string;
 }>;
@@ -30,4 +30,4 @@ type ErrorType = Prettify<{
  * const todo = json.payload; // no error, type of Todo.
  * ```
  */
-export type ApiResponse<T> = SuccessType<T> | ErrorType;
+export type ApiResponse<T> = ApiSuccess<T> | ApiError;

--- a/js/src/lib/api/common/apiResponse.ts
+++ b/js/src/lib/api/common/apiResponse.ts
@@ -1,12 +1,14 @@
-type SuccessType<T> = {
+import { Prettify } from "@/lib/prettify";
+
+type SuccessType<T> = Prettify<{
   success: true;
   message: string;
   payload: T;
-};
+}>;
 
-type ErrorType = {
+type ErrorType = Prettify<{
   success: false;
   message: string;
-};
+}>;
 
-export type ApiResponse<T> = SuccessType<T> | ErrorType;
+type ApiResponse<T> = SuccessType<T> | ErrorType;

--- a/js/src/lib/api/common/apiResponse.ts
+++ b/js/src/lib/api/common/apiResponse.ts
@@ -11,4 +11,23 @@ type ErrorType = Prettify<{
   message: string;
 }>;
 
-type ApiResponse<T> = SuccessType<T> | ErrorType;
+/**
+ * Generic wrapper for all responses returned by Codebloom's backend.
+ *
+ * @note - The `payload` of type `T` attribute is only available in the SuccessType, not ErrorType.
+ * You can attempt to access `payload` by checking if `success` is true.
+ *
+ * @example
+ * ```ts
+ * const json = (await response.json()) as ApiResponse<Todo>;
+ *
+ * json.payload; // Property 'payload' does not exist on type 'ApiResponse<Todo>'.
+ *
+ * if (!json.success) {
+ *  return;
+ * }
+ *
+ * const todo = json.payload; // no error, type of Todo.
+ * ```
+ */
+export type ApiResponse<T> = SuccessType<T> | ErrorType;

--- a/js/src/lib/api/queries/admin/index.ts
+++ b/js/src/lib/api/queries/admin/index.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from "@/lib/api/common/apiResponse";
+import { UnknownApiResponse } from "@/lib/api/common/apiResponse";
 import { Page } from "@/lib/api/common/page";
 import { Leaderboard } from "@/lib/api/types/leaderboard";
 import { User } from "@/lib/api/types/user";
@@ -21,7 +21,7 @@ export const useToggleAdminMutation = () => {
         "all",
         metadata.page,
         metadata.debouncedQuery,
-      ]) as ApiResponse<Page<User[]>>;
+      ]) as UnknownApiResponse<Page<User[]>>;
 
       // Impossible, just handle it to make TS happy and narrow the type.
       if (!previousApiResponse.success) {
@@ -115,7 +115,7 @@ async function toggleUserAdmin({
     }),
   });
 
-  const json = (await response.json()) as ApiResponse<User>;
+  const json = (await response.json()) as UnknownApiResponse<User>;
 
   return json;
 }
@@ -127,13 +127,13 @@ export async function createLeaderboard(leaderboard: { name: string }) {
     body: JSON.stringify(leaderboard),
   });
 
-  const json = (await response.json()) as ApiResponse<Leaderboard>;
+  const json = (await response.json()) as UnknownApiResponse<Leaderboard>;
   return json;
 }
 
 export const useCreateLeaderboardMutation = () => {
   const queryClient = useQueryClient();
-  return useMutation<ApiResponse<Leaderboard>, Error, { name: string }>({
+  return useMutation<UnknownApiResponse<Leaderboard>, Error, { name: string }>({
     mutationFn: createLeaderboard,
     onSuccess: async (data) => {
       if (data.success) {

--- a/js/src/lib/api/queries/auth/index.ts
+++ b/js/src/lib/api/queries/auth/index.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from "@/lib/api/common/apiResponse";
+import { UnknownApiResponse } from "@/lib/api/common/apiResponse";
 import { Session } from "@/lib/api/types/session";
 import { User } from "@/lib/api/types/user";
 import { useQuery } from "@tanstack/react-query";
@@ -18,7 +18,7 @@ async function validateAuthentication() {
     method: "GET",
   });
 
-  const json = (await response.json()) as ApiResponse<{
+  const json = (await response.json()) as UnknownApiResponse<{
     user: User;
     session: Session;
   }>;

--- a/js/src/lib/api/queries/auth/leetcode/index.ts
+++ b/js/src/lib/api/queries/auth/leetcode/index.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from "@/lib/api/common/apiResponse";
+import { UnknownApiResponse } from "@/lib/api/common/apiResponse";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 /**
@@ -40,7 +40,7 @@ async function updateLeetcodeUsername({
     },
   });
 
-  const json = (await res.json()) as ApiResponse<undefined>;
+  const json = (await res.json()) as UnknownApiResponse<undefined>;
 
   return { success: json.success, message: json.message };
 }
@@ -48,7 +48,7 @@ async function updateLeetcodeUsername({
 async function getLeetcodeQueryKey() {
   const res = await fetch("/api/leetcode/key");
 
-  const json = (await res.json()) as ApiResponse<string>;
+  const json = (await res.json()) as UnknownApiResponse<string>;
 
   if (!json.success) {
     return { success: json.success, message: json.message, payload: null };

--- a/js/src/lib/api/queries/leaderboard/index.ts
+++ b/js/src/lib/api/queries/leaderboard/index.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from "@/lib/api/common/apiResponse";
+import { UnknownApiResponse } from "@/lib/api/common/apiResponse";
 import { Page } from "@/lib/api/common/page";
 import { Leaderboard } from "@/lib/api/types/leaderboard";
 import { User, UserWithScore } from "@/lib/api/types/user";
@@ -159,7 +159,9 @@ async function fetchLeaderboardUsers({
     },
   );
 
-  const json = (await response.json()) as ApiResponse<Page<UserWithScore[]>>;
+  const json = (await response.json()) as UnknownApiResponse<
+    Page<UserWithScore[]>
+  >;
 
   return json;
 }
@@ -169,7 +171,7 @@ async function useCurrentLeaderboardMetadata() {
     method: "GET",
   });
 
-  const json = (await response.json()) as ApiResponse<Leaderboard>;
+  const json = (await response.json()) as UnknownApiResponse<Leaderboard>;
 
   return json;
 }
@@ -182,7 +184,7 @@ async function updateTotalPoints() {
     },
   });
 
-  const json = (await res.json()) as ApiResponse<{
+  const json = (await res.json()) as UnknownApiResponse<{
     acceptedSubmissions: { title: string; points: number }[];
   }>;
 
@@ -200,7 +202,9 @@ export async function getMyRecentLeaderboardData({
 }) {
   const res = await fetch(`/api/leaderboard/current/user/${userId}`);
 
-  const json = (await res.json()) as ApiResponse<User & { totalScore: number }>;
+  const json = (await res.json()) as UnknownApiResponse<
+    User & { totalScore: number }
+  >;
 
   return json;
 }
@@ -210,7 +214,7 @@ async function fetchAllLeaderboardsMetadata() {
     method: "GET",
   });
 
-  const json = (await response.json()) as ApiResponse<Leaderboard[]>;
+  const json = (await response.json()) as UnknownApiResponse<Leaderboard[]>;
 
   return json;
 }

--- a/js/src/lib/api/queries/potd/index.ts
+++ b/js/src/lib/api/queries/potd/index.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from "@/lib/api/common/apiResponse";
+import { UnknownApiResponse } from "@/lib/api/common/apiResponse";
 import { POTD } from "@/lib/api/types/potd";
 import { useQuery } from "@tanstack/react-query";
 
@@ -12,7 +12,7 @@ export const useFetchPotdQuery = () => {
 async function fetchPotd() {
   const res = await fetch("/api/leetcode/potd");
 
-  const json = (await res.json()) as ApiResponse<POTD>;
+  const json = (await res.json()) as UnknownApiResponse<POTD>;
 
   return json;
 }

--- a/js/src/lib/api/queries/submissions/index.ts
+++ b/js/src/lib/api/queries/submissions/index.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from "@/lib/api/common/apiResponse";
+import { UnknownApiResponse } from "@/lib/api/common/apiResponse";
 import { Question } from "@/lib/api/types/question";
 import { User } from "@/lib/api/types/user";
 import { useQuery } from "@tanstack/react-query";
@@ -23,7 +23,7 @@ async function fetchSubmissionDetails({
   submissionId?: string;
 }) {
   const res = await fetch(`/api/leetcode/submission/${submissionId}`);
-  const json = (await res.json()) as ApiResponse<
+  const json = (await res.json()) as UnknownApiResponse<
     Question & Pick<User, "discordName" | "leetcodeUsername" | "nickname">
   >;
 

--- a/js/src/lib/api/queries/user/index.ts
+++ b/js/src/lib/api/queries/user/index.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from "@/lib/api/common/apiResponse";
+import { UnknownApiResponse } from "@/lib/api/common/apiResponse";
 import { Page } from "@/lib/api/common/page";
 import { Question } from "@/lib/api/types/question";
 import { User } from "@/lib/api/types/user";
@@ -142,7 +142,7 @@ export const useGetAllUsersQuery = ({
 async function fetchUserProfile({ userId }: { userId?: string }) {
   const response = await fetch(`/api/user/${userId ?? ""}/profile`);
 
-  const json = (await response.json()) as ApiResponse<User>;
+  const json = (await response.json()) as UnknownApiResponse<User>;
 
   return json;
 }
@@ -162,7 +162,7 @@ async function fetchUserSubmissions({
     `/api/user/${userId ?? ""}/submissions?page=${page}&query=${query}&pageSize=${pageSize}`,
   );
 
-  const json = (await response.json()) as ApiResponse<Page<Question[]>>;
+  const json = (await response.json()) as UnknownApiResponse<Page<Question[]>>;
 
   return json;
 }
@@ -180,7 +180,7 @@ async function fetchAllUsers({
     `/api/user/all?page=${page}&query=${query}&pageSize=${pageSize}`,
   );
 
-  const json = (await response.json()) as ApiResponse<Page<User[]>>;
+  const json = (await response.json()) as UnknownApiResponse<Page<User[]>>;
 
   return json;
 }

--- a/js/src/lib/prettify/index.ts
+++ b/js/src/lib/prettify/index.ts
@@ -1,0 +1,7 @@
+/**
+ * The `Prettify` helper is a utility type that takes
+ * an object type and makes the hover overlay more readable.
+ */
+export type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};


### PR DESCRIPTION
- Renamed `ApiResponse` to `UnknownApiResponse` to improve clarity about whether or not the `payload` attribute is available
- Renamed the success and error types to be a little less vague. The intent is so that if anyone were to read the source code, it would be a little easier to understand the purpose of each type.
- Wrapped the success and error types in Prettify so that their types are more opaque when read, for example, via a hover in VSCode.
- Added some examples and documentation on `UnknownApiResponse`.