### PR TITLE
Implement JDAClient + Add weekly Discord leaderboard message 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ DATABASE_PASSWORD=enterpasswordhere
 
 # For Discord authentication, pretty self explanatory.
 DISCORD_CLIENT_ID=
+DISCORD_CHANNEL_ID=
 DISCORD_CLIENT_SECRET=
 
 # The server that the bot lives on. This usually points to the Patina server.

--- a/src/main/java/com/patina/codebloom/jda/JDAProperties.java
+++ b/src/main/java/com/patina/codebloom/jda/JDAProperties.java
@@ -6,7 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class JDAProperties {
     private String token;
     private String id;
-    private long channelId;
+    private String channelId;
 
     public String getToken() {
         return token;
@@ -24,11 +24,15 @@ public class JDAProperties {
         this.id = id;
     }
 
-    public long getChannelId() {
+    public String getChannelId() {
         return channelId;
     }
 
-    public void setChannelId(final long channelId) {
+    public long getChannelIdAsLong() {
+        return Long.valueOf(channelId);
+    }
+
+    public void setChannelId(final String channelId) {
         this.channelId = channelId;
     }
 }

--- a/src/main/java/com/patina/codebloom/jda/JDAProperties.java
+++ b/src/main/java/com/patina/codebloom/jda/JDAProperties.java
@@ -5,8 +5,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "jda.discord")
 public class JDAProperties {
     private String token;
-
     private String id;
+    private long channelId;
 
     public String getToken() {
         return token;
@@ -24,4 +24,11 @@ public class JDAProperties {
         this.id = id;
     }
 
+    public long getChannelId() {
+        return channelId;
+    }
+
+    public void setChannelId(final long channelId) {
+        this.channelId = channelId;
+    }
 }

--- a/src/main/java/com/patina/codebloom/jda/client/JDAClient.java
+++ b/src/main/java/com/patina/codebloom/jda/client/JDAClient.java
@@ -75,7 +75,7 @@ public class JDAClient {
 
     public long getPatinaLeetcodeChannelId() {
         isJdaReadyOrThrow();
-        return jdaInitializer.getJdaProperties().getChannelId();
+        return jdaInitializer.getJdaProperties().getChannelIdAsLong();
     }
 
     public Guild getGuildById(final String guildId) {

--- a/src/main/java/com/patina/codebloom/jda/client/JDAClient.java
+++ b/src/main/java/com/patina/codebloom/jda/client/JDAClient.java
@@ -1,0 +1,179 @@
+package com.patina.codebloom.jda.client;
+
+import java.awt.Color;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.ScreenshotType;
+import com.patina.codebloom.common.db.models.leaderboard.Leaderboard;
+import com.patina.codebloom.common.db.models.user.UserWithScore;
+import com.patina.codebloom.common.db.repos.leaderboard.LeaderboardRepository;
+import com.patina.codebloom.jda.JDAInitializer;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.utils.FileUpload;
+
+/**
+ * Use this client to interface with any required Discord bot logic.
+ */
+@Component
+public class JDAClient {
+    @Autowired
+    private JDAInitializer jdaInitializer;
+    @Autowired
+    private LeaderboardRepository leaderboardRepository;
+    private JDA jda;
+    private static final Logger LOGGER = LoggerFactory.getLogger(JDAClient.class);
+
+    JDAClient() {
+    }
+
+    private void isJdaReadyOrThrow() {
+        if (jda == null) {
+            throw new RuntimeException("You must call connect() first.");
+        }
+
+        try {
+            jda.awaitReady();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Something went wrong when awaiting JDA", e);
+        }
+    }
+
+    public void connect() throws Exception {
+        jda = jdaInitializer.jda();
+    }
+
+    public List<Guild> getGuilds() {
+        isJdaReadyOrThrow();
+        return jda.getGuilds();
+    }
+
+    /**
+     * This is the recommended way to access Patina server's Discord ID.
+     */
+    public String getPatinaGuildId() {
+        isJdaReadyOrThrow();
+        return jdaInitializer.getJdaProperties().getId();
+    }
+
+    public long getPatinaLeetcodeChannelId() {
+        isJdaReadyOrThrow();
+        return jdaInitializer.getJdaProperties().getChannelId();
+    }
+
+    public Guild getGuildById(final String guildId) {
+        isJdaReadyOrThrow();
+        return jda.getGuilds().stream().filter(g -> g.getId().equals(guildId)).findFirst().orElse(null);
+    }
+
+    public List<Member> getMemberListByGuildId(final String guildId) {
+        isJdaReadyOrThrow();
+        List<Guild> guilds = jda.getGuilds();
+
+        Optional<Guild> optionalGuild = guilds.stream().filter(g -> g.getId().equals(guildId)).findFirst();
+
+        if (optionalGuild.isEmpty()) {
+            return List.of();
+        }
+
+        return optionalGuild.get().getMembers();
+    }
+
+    /**
+     * Sends a screenshot of the Patina leaderboard (as well as tagging the top 3
+     * Patina users) to a given guild and channel of your choosing.
+     */
+    public void sendLeaderboardMessage(final String guildId, final long channelId) {
+        isJdaReadyOrThrow();
+        Guild guild = getGuildById(guildId);
+        if (guild == null) {
+            LOGGER.error("Guild does not exist to send leaderboard message.");
+            return;
+        }
+        TextChannel channel = guild.getTextChannelById(channelId);
+        if (channel == null) {
+            LOGGER.error("Channel does not exist on the given guild.");
+            return;
+        }
+
+        try (Playwright playwright = Playwright.create()) {
+            Browser browser = playwright.firefox().launch();
+            Page page = browser.newPage();
+            page.navigate("https://codebloom.patinanetwork.org/leaderboard?patina=true");
+
+            page.waitForTimeout(5_000);
+
+            byte[] screenshotBytes = page.screenshot(
+                            new Page.ScreenshotOptions().setType(ScreenshotType.PNG).setFullPage(true));
+
+            List<UserWithScore> users = leaderboardRepository.getRecentLeaderboardUsers(1, 5, "", true);
+
+            browser.close();
+
+            Leaderboard currentLeaderboard = leaderboardRepository.getRecentLeaderboardMetadata();
+            LocalDateTime shouldExpireByTime = currentLeaderboard.getShouldExpireBy();
+
+            Duration remaining = Duration.between(LocalDateTime.now(), shouldExpireByTime);
+
+            long daysLeft = remaining.toDays();
+            long hoursLeft = remaining.toHours() % 24;
+            long minutesLeft = remaining.toMinutes() % 60;
+
+            String description = String.format("""
+                            Hey everyone! Here is a weekly update on the LeetCode leaderboard for our very own Patina members!
+
+                            🥇- <@%s>
+                            🥈- <@%s>
+                            🥉- <@%s>
+
+                            To view the rest of the members, visit the website or check out the image embedded in this message!
+
+                            Just as a reminder, there's %d day(s) %d hour(s) %d minute(s) left until the leaderboard closes, so keep grinding!
+
+
+                            See you next week!
+
+                            Beep boop,
+                            Codebloom
+                            <https://codebloom.patinanetwork.org>
+                            """,
+                            users.get(0).getDiscordId(),
+                            users.get(1).getDiscordId(),
+                            users.get(2).getDiscordId(),
+                            daysLeft,
+                            hoursLeft,
+                            minutesLeft);
+
+            MessageEmbed embed = new EmbedBuilder()
+                            .setTitle("🏆 Patina Leaderboard - " + currentLeaderboard.getName())
+                            .setDescription(description)
+                            .setFooter("Codebloom - LeetCode Leaderboard for Patina Network", "https://codebloom.patinanetwork.org/favicon.ico")
+                            .setImage("attachment://leaderboard.png")
+                            .setColor(new Color(69, 129, 103)).build();
+
+            channel.sendFiles(FileUpload.fromData(screenshotBytes, "leaderboard.png"))
+                            .setEmbeds(embed)
+                            .queue();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/patina/codebloom/scheduled/discord/WeeklyLeaderboard.java
+++ b/src/main/java/com/patina/codebloom/scheduled/discord/WeeklyLeaderboard.java
@@ -1,0 +1,30 @@
+package com.patina.codebloom.scheduled.discord;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.patina.codebloom.jda.client.JDAClient;
+
+@Component
+public class WeeklyLeaderboard {
+    // private static final Logger LOGGER =
+    // LoggerFactory.getLogger(WeeklyLeaderboard.class);
+
+    private final JDAClient jdaClient;
+
+    WeeklyLeaderboard(final JDAClient jdaClient) {
+        this.jdaClient = jdaClient;
+    }
+
+    @Scheduled(cron = "0 0 13 ? * SAT")
+    public void sendWeeklyLeaderboard() {
+        try {
+            jdaClient.connect();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to initialize JDAClient", e);
+        }
+
+        jdaClient.sendLeaderboardMessage(jdaClient.getPatinaGuildId(), jdaClient.getPatinaLeetcodeChannelId());
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,7 @@ github.password=${GH_PASSWORD}
 
 jda.discord.token=${DISCORD_TOKEN}
 jda.discord.id=${DISCORD_SERVER_ID}
+jda.discord.channel-id=${DISCORD_CHANNEL_ID}
 
 email.host=${EMAIL_HOST}
 email.port=${EMAIL_PORT}


### PR DESCRIPTION
Implement JDAClient to interface with JDA logic instead of directly interfacing with JDA. Added some helper functions, including the ability to send a Patina leaderboard message to a channel and guild. In the future, this logic can be trivially modified to report school specific leaderboards to their respective Discord servers as well.