### PR TITLE
Implement some testing configs + add some example tests

### DIFF
--- a/db/repeated/R__Mock_v2.SQL
+++ b/db/repeated/R__Mock_v2.SQL
@@ -1,0 +1,9 @@
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM "User" LIMIT 1) THEN
+        UPDATE "User"
+        SET admin = true
+        WHERE id = 'ed3bfe18-e42a-467f-b4fa-07e8da4d2555';
+    END IF;
+END $$
+

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
             <version>5.0.0</version>
         </dependency>
         <dependency>
+            <!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured-all</artifactId>
+            <version>5.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.11.0</version>

--- a/src/main/java/com/patina/codebloom/common/db/models/user/User.java
+++ b/src/main/java/com/patina/codebloom/common/db/models/user/User.java
@@ -2,6 +2,7 @@ package com.patina.codebloom.common.db.models.user;
 
 import java.util.ArrayList;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.patina.codebloom.common.db.models.usertag.UserTag;
 
 public class User {
@@ -22,6 +23,7 @@ public class User {
      */
     private ArrayList<UserTag> tags;
 
+    @JsonCreator
     public User(
                     final String id,
                     final String discordId,

--- a/src/main/java/com/patina/codebloom/common/dto/ApiResponder.java
+++ b/src/main/java/com/patina/codebloom/common/dto/ApiResponder.java
@@ -1,5 +1,6 @@
 package com.patina.codebloom.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -11,6 +12,7 @@ public final class ApiResponder<T> {
     private T payload;
     private String message;
 
+    @JsonCreator
     private ApiResponder(final boolean success, final String message, final T payload) {
         this.success = success;
         this.payload = payload;

--- a/src/test/java/com/patina/codebloom/ApiControllerTest.java
+++ b/src/test/java/com/patina/codebloom/ApiControllerTest.java
@@ -1,0 +1,59 @@
+package com.patina.codebloom;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import com.patina.codebloom.common.dto.ApiResponder;
+import com.patina.codebloom.utilities.ServerMetadataObject;
+
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiControllerTest {
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUpPort() {
+        RestAssured.port = port;
+    }
+
+    @BeforeAll
+    static void setUpUri() {
+        RestAssured.baseURI = "http://localhost";
+    }
+
+    @Test
+    void testBaseApiRoute() {
+        ApiResponder<ServerMetadataObject> apiResponder = RestAssured
+                        .given()
+                        .when()
+                        .get("/api")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .as(new TypeRef<ApiResponder<ServerMetadataObject>>() {
+                        });
+
+        assertTrue(apiResponder.isSuccess() == true, "Testing apiResponder success is true");
+        assertTrue(apiResponder.getMessage() != null, "Testing apiResponder message is not null");
+        ServerMetadataObject serverMetadataObject = apiResponder.getPayload();
+        assertTrue(serverMetadataObject != null, "Testing server metadata object is not null");
+        assertTrue(serverMetadataObject.getVersion() != null, "Testing server version is not null");
+        assertTrue(serverMetadataObject.getName() != null, "Testing server name is not null");
+        List<String> authors = serverMetadataObject.getAuthors();
+        assertTrue(authors != null, "Testing authors list is not null");
+        assertTrue(authors.size() == 4, "Testing length of authors, expected 4.");
+    }
+}

--- a/src/test/java/com/patina/codebloom/admin/AdminControllerTest.java
+++ b/src/test/java/com/patina/codebloom/admin/AdminControllerTest.java
@@ -1,0 +1,74 @@
+package com.patina.codebloom.admin;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.patina.codebloom.common.db.models.user.User;
+import com.patina.codebloom.common.dto.ApiResponder;
+import com.patina.codebloom.testconfig.TestProtector;
+
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import(TestProtector.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AdminControllerTest {
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUpPort() {
+        RestAssured.port = port;
+    }
+
+    @BeforeAll
+    static void setUpUri() {
+        RestAssured.baseURI = "http://localhost";
+    }
+
+    private String buildTestAdminToggleBody(final String id, final boolean toggleTo) throws JsonProcessingException {
+        Map<String, Object> body = new HashMap<>();
+        body.put("id", id);
+        body.put("toggleTo", toggleTo);
+
+        return new ObjectMapper().writeValueAsString(body);
+    }
+
+    @Test
+    void testAdminToggle() throws JsonProcessingException {
+        ApiResponder<User> apiResponder = RestAssured
+                        .given()
+                        .when()
+                        // Everyone should have this user ID on their dev db from the repeated
+                        // migration.
+                        .header("Content-Type", "application/json")
+                        .body(buildTestAdminToggleBody("e0b45c9a-9c8f-4a39-9373-39cf2a5f8055", false))
+                        .post("/api/admin/user/admin/toggle")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .as(new TypeRef<ApiResponder<User>>() {
+                        });
+
+        assertTrue(apiResponder != null, "Expected apiResponder to not be equal to null");
+        assertTrue(apiResponder.isSuccess() == true, "Testing apiResponder success is true");
+        assertTrue(apiResponder.getMessage() != null, "Testing apiResponder message is not null");
+        User user = apiResponder.getPayload();
+        assertTrue(user != null, "Expected user to not be equal to null");
+        assertTrue(user.isAdmin() == false, "Expected user to not be admin");
+    }
+}

--- a/src/test/java/com/patina/codebloom/leetcode/LeetcodeApiHandlerTest.java
+++ b/src/test/java/com/patina/codebloom/leetcode/LeetcodeApiHandlerTest.java
@@ -1,4 +1,4 @@
-package com.patina.codebloom;
+package com.patina.codebloom.leetcode;
 
 import java.util.ArrayList;
 

--- a/src/test/java/com/patina/codebloom/leetcode/ScoreCalculatorTest.java
+++ b/src/test/java/com/patina/codebloom/leetcode/ScoreCalculatorTest.java
@@ -1,4 +1,4 @@
-package com.patina.codebloom;
+package com.patina.codebloom.leetcode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/patina/codebloom/testconfig/TestProtector.java
+++ b/src/test/java/com/patina/codebloom/testconfig/TestProtector.java
@@ -1,0 +1,52 @@
+package com.patina.codebloom.testconfig;
+
+import java.time.LocalDateTime;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.patina.codebloom.common.db.models.Session;
+import com.patina.codebloom.common.db.models.user.User;
+import com.patina.codebloom.common.db.repos.user.UserRepository;
+import com.patina.codebloom.common.security.AuthenticationObject;
+import com.patina.codebloom.common.security.Protector;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Use this if you need to override the admin behavior.
+ *
+ * NOTE: THE USER EXISTS AND IS REAL, BUT THE SESSION IS NOT!
+ *
+ * TODO - Create an infinitely long session to use for this case.
+ *
+ * @see <a href=
+ * "https://github.com/tahminator/codebloom/tree/main/src/test/java/com/patina/codebloom/admin/AdminControllerTest.java">Example
+ * on how to use this test config</a>
+ */
+@TestConfiguration
+public class TestProtector {
+    private UserRepository userRepository;
+
+    public TestProtector(final UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    public Protector protector() {
+        return new Protector(null, userRepository) {
+            @Override
+            public AuthenticationObject validateSession(HttpServletRequest request) {
+                User mockAdminUser = userRepository.getUserById("ed3bfe18-e42a-467f-b4fa-07e8da4d2555");
+                Session fakeSession = new Session("ed3bfe18-e42a-467f-b4fa-07e8da4d2555", LocalDateTime.now().plusYears(10L));
+                return new AuthenticationObject(mockAdminUser, fakeSession);
+            }
+
+            // User is an admin, so just send the same thing.
+            @Override
+            public AuthenticationObject validateAdminSession(HttpServletRequest request) {
+                return validateSession(request);
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Added some missing RestAssured dependencies
- Implement a TestProtector that uses a user that exists in all dev/CI dbs that has admin access, allowing us to test authenticated endpoints
- Implement a test for AdminController toggling user's admin status
- Implement a test for base ApiController returning the ServerMetadataObject