### PR TITLE
Fix openapi-typescript infinite loop (DESC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,16 @@ migrate-prod:
 	dotenvx run -f .env.production -- ./mvnw flyway:migrate -Dflyway.locations=filesystem:./db/migration
 
 java-dev:
-	dotenvx run -- ./mvnw spring-boot:run
+	dotenvx run -- ./mvnw -Dspring-boot.run.profiles=dev spring-boot:run
 
 js-dev:
 	cd js && pnpm run dev
 
 types-dev:
-	cd js && pnpm run generate:dev
+	cd js && pnpm run generate
 
 dev:
-	pnpm i -g concurrently && concurrently "make java-dev" "make js-dev" "make types-dev"
+	pnpm i -g concurrently && concurrently "make java-dev" "make js-dev"
 
 backend-install:
 	dotenvx run -- ./mvnw install -DskipTests=true

--- a/docs/backend/automatic-type-gen.md
+++ b/docs/backend/automatic-type-gen.md
@@ -1,0 +1,9 @@
+# Automatic type generation
+
+We use `openapi-typescript` to read our OpenAPI schema from the backend and convert into a schema file for the frontend to use and consume.
+
+This command only runs locally, and the generated schema file is checked into version control. The command is run once per start (this includes reloading the local server from file changes) via [JSTypesGenerator.java](https://github.com/tahminator/codebloom/blob/fix-type-gen-infinite-loop/src/main/java/com/patina/codebloom/utilities/JSTypesGenerator.java).
+
+WIP
+
+For more details about the actual command or how the schema is used on the frontend, check [the frontend document](https://github.com/tahminator/codebloom/tree/fix-type-gen-infinite-loop)

--- a/docs/frontend/automatic-type-gen.md
+++ b/docs/frontend/automatic-type-gen.md
@@ -1,0 +1,15 @@
+# Automatic type generation
+
+We use `openapi-typescript` to read our OpenAPI schema from the backend and convert into a schema file for the frontend to use and consume.
+
+There are two scripts inside of the `package.json`:
+
+- `generate` - Runs the generation script one time
+
+- `generate:dev` - Runs the generation every time any `*.java` file changes (NOT RECOMMENDED)
+
+The command requires the server to be running, but in most cases you won't have to worry about that because the backend already runs this command anytime the dev server restarts.
+
+WIP
+
+For more details about how the backend runs the script or how it generates the schema, check [the frontend document](https://github.com/tahminator/codebloom/tree/fix-type-gen-infinite-loop)

--- a/src/main/java/com/patina/codebloom/utilities/JSTypesGenerator.java
+++ b/src/main/java/com/patina/codebloom/utilities/JSTypesGenerator.java
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class JSTypesGenerator implements CommandLineRunner {
     @Override
-    public void run(String... args) throws Exception {
+    public void run(final String... args) throws Exception {
         log.info("Type generation command starting...");
         Process process = new ProcessBuilder("make", "types-dev")
                         .inheritIO()

--- a/src/main/java/com/patina/codebloom/utilities/JSTypesGenerator.java
+++ b/src/main/java/com/patina/codebloom/utilities/JSTypesGenerator.java
@@ -1,0 +1,26 @@
+package com.patina.codebloom.utilities;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Profile("dev")
+@Component
+@Slf4j
+public class JSTypesGenerator implements CommandLineRunner {
+    @Override
+    public void run(String... args) throws Exception {
+        log.info("Type generation command starting...");
+        Process process = new ProcessBuilder("make", "types-dev")
+                        .inheritIO()
+                        .start();
+        int exitCode = process.waitFor();
+        if (exitCode == 0) {
+            log.info("Type generation command completed successfully.");
+        } else {
+            log.error("Type generation command failed with exit code {}", exitCode);
+        }
+    }
+}


### PR DESCRIPTION
Fix the openapi-typescript generation loop by moving it out of the Makefile and instead registering the command under a command line runner & component inside of the actual Java process (only in dev)