### PR TITLE
School modal hack

### DIFF
--- a/js/src/app/settings/_components/SchoolEmailModal.tsx
+++ b/js/src/app/settings/_components/SchoolEmailModal.tsx
@@ -38,6 +38,7 @@ export default function SchoolEmailModal({
           });
           if (data.success) {
             form.reset();
+            toggle();
           }
         },
       },

--- a/js/src/lib/api/queries/auth/school/index.ts
+++ b/js/src/lib/api/queries/auth/school/index.ts
@@ -19,7 +19,9 @@ export const useVerifySchoolMutation = () => {
     mutationFn: verifySchool,
     onSuccess: async (data) => {
       if (data.success) {
-        await queryClient.invalidateQueries();
+        setTimeout(async () => {
+          await queryClient.invalidateQueries();
+        }, 100);
       }
     },
   });

--- a/js/src/lib/api/queries/auth/school/index.ts
+++ b/js/src/lib/api/queries/auth/school/index.ts
@@ -19,6 +19,9 @@ export const useVerifySchoolMutation = () => {
     mutationFn: verifySchool,
     onSuccess: async (data) => {
       if (data.success) {
+        /**
+         * https://github.com/tahminator/codebloom/pull/256#issue-3286903003
+         */
         setTimeout(async () => {
           await queryClient.invalidateQueries();
         }, 100);


### PR DESCRIPTION
Even though invalidateQueries is an async function, it is blocking the execution of the `mutate()` hook level `onSuccess`, which is blocking the notification message update to show the response from the server. An acceptable hack is to wrap invalidateQueries in a setTimeout, and defer it's execution via a callback 100ms from the register point.
