### PR TITLE
Abstract the error reporting logic into ErrorReporter, so the logic c…

### DIFF
--- a/src/main/java/com/patina/codebloom/CodebloomApplication.java
+++ b/src/main/java/com/patina/codebloom/CodebloomApplication.java
@@ -2,10 +2,12 @@ package com.patina.codebloom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class CodebloomApplication {
     public static void main(final String[] args) {
         SpringApplication.run(CodebloomApplication.class, args);

--- a/src/main/java/com/patina/codebloom/api/reporter/ReporterController.java
+++ b/src/main/java/com/patina/codebloom/api/reporter/ReporterController.java
@@ -1,7 +1,5 @@
 package com.patina.codebloom.api.reporter;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,8 +12,6 @@ import com.patina.codebloom.api.reporter.body.IngestErrorsBody;
 import com.patina.codebloom.common.dto.ApiResponder;
 import com.patina.codebloom.common.dto.Empty;
 import com.patina.codebloom.common.reporter.ErrorReporter;
-import com.patina.codebloom.common.reporter.report.Report;
-import com.patina.codebloom.common.reporter.report.location.Location;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 

--- a/src/main/java/com/patina/codebloom/api/reporter/ReporterController.java
+++ b/src/main/java/com/patina/codebloom/api/reporter/ReporterController.java
@@ -1,0 +1,54 @@
+package com.patina.codebloom.api.reporter;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.patina.codebloom.api.reporter.body.IngestErrorsBody;
+import com.patina.codebloom.common.dto.ApiResponder;
+import com.patina.codebloom.common.dto.Empty;
+import com.patina.codebloom.common.reporter.ErrorReporter;
+import com.patina.codebloom.common.reporter.report.Report;
+import com.patina.codebloom.common.reporter.report.location.Location;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@Tag(name = "Error reporting route", description = "This controller allows the frontend to report any runtime errors, which will then be ingested by the server.")
+@RequestMapping("/api/reporting")
+public class ReporterController {
+    private final ErrorReporter errorReporter;
+
+    public ReporterController(final ErrorReporter errorReporter) {
+        this.errorReporter = errorReporter;
+    }
+
+    @PostMapping("")
+    public ResponseEntity<ApiResponder<Empty>> ingestErrors(final @RequestBody IngestErrorsBody ingestErrorsBody) {
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        // List<String> traces = ingestErrorsBody.getTraces();
+        //
+        // if (traces.size() > 3) {
+        // String combined = String.join("\n\n", traces);
+        // errorReporter.report(Report.builder()
+        // .location(Location.FRONTEND)
+        // .stackTrace(combined.getBytes())
+        // .build());
+        // } else {
+        // for (String trace : traces) {
+        // errorReporter.report(Report.builder()
+        // .location(Location.FRONTEND)
+        // .stackTrace(trace.getBytes())
+        // .build());
+        // }
+        // }
+        //
+        // return ResponseEntity.ok(ApiResponder.success("Received!", Empty.of()));
+    }
+}

--- a/src/main/java/com/patina/codebloom/api/reporter/body/IngestErrorsBody.java
+++ b/src/main/java/com/patina/codebloom/api/reporter/body/IngestErrorsBody.java
@@ -1,0 +1,14 @@
+package com.patina.codebloom.api.reporter.body;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@Jacksonized
+public class IngestErrorsBody {
+    private List<String> traces;
+}

--- a/src/main/java/com/patina/codebloom/common/reporter/ErrorReporter.java
+++ b/src/main/java/com/patina/codebloom/common/reporter/ErrorReporter.java
@@ -1,0 +1,47 @@
+package com.patina.codebloom.common.reporter;
+
+import java.awt.Color;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.patina.codebloom.common.reporter.report.Report;
+import com.patina.codebloom.common.time.StandardizedLocalDateTime;
+import com.patina.codebloom.jda.client.JDAClient;
+import com.patina.codebloom.jda.client.options.EmbeddedMessageOptions;
+
+@Component
+public class ErrorReporter {
+    private final JDAClient jdaClient;
+
+    public ErrorReporter(final JDAClient jdaClient) {
+        this.jdaClient = jdaClient;
+    }
+
+    @Async
+    public void report(final Report report) {
+        String description = String.format("""
+                        An error occurred in Codebloom.
+
+                        Active environment(s): %s
+                        Current Time: %s
+                        Location: %s
+
+                        Check attachment for stack trace.""",
+                        report.getEnvironments(),
+                        StandardizedLocalDateTime.now().toString(),
+                        report.getLocation().getResolvedName());
+
+        jdaClient.sendEmbedWithImage(
+                        EmbeddedMessageOptions.builder()
+                                        .guildId(jdaClient.getJdaReportingProperties().getGuildId())
+                                        .channelId(jdaClient.getJdaReportingProperties().getChannelId())
+                                        .title("Something went wrong!")
+                                        .description(description)
+                                        .color(Color.RED)
+                                        .fileName("stacktrace.txt")
+                                        .fileBytes(report.getStackTrace())
+                                        .build());
+    }
+
+}

--- a/src/main/java/com/patina/codebloom/common/reporter/report/Report.java
+++ b/src/main/java/com/patina/codebloom/common/reporter/report/Report.java
@@ -1,0 +1,22 @@
+package com.patina.codebloom.common.reporter.report;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import com.patina.codebloom.common.reporter.report.location.Location;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@Jacksonized
+public class Report {
+    @Builder.Default
+    private List<String> environments = List.of("N/A");
+    @Builder.Default
+    private Location location = Location.UNKNOWN;
+    @Builder.Default
+    private byte[] stackTrace = "N/A".getBytes(StandardCharsets.UTF_8);
+}

--- a/src/main/java/com/patina/codebloom/common/reporter/report/location/Location.java
+++ b/src/main/java/com/patina/codebloom/common/reporter/report/location/Location.java
@@ -1,0 +1,14 @@
+package com.patina.codebloom.common.reporter.report.location;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum Location {
+    BACKEND("Backend"),
+    FRONTEND("Frontend"),
+    UNKNOWN("Unknown");
+
+    private final String resolvedName;
+}

--- a/src/main/java/com/patina/codebloom/utilities/GlobalExceptionHandler.java
+++ b/src/main/java/com/patina/codebloom/utilities/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.patina.codebloom.utilities;
 
-import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -16,8 +15,6 @@ import com.patina.codebloom.common.env.Env;
 import com.patina.codebloom.common.reporter.ErrorReporter;
 import com.patina.codebloom.common.reporter.report.Report;
 import com.patina.codebloom.common.reporter.report.location.Location;
-import com.patina.codebloom.common.time.StandardizedLocalDateTime;
-import com.patina.codebloom.jda.client.options.EmbeddedMessageOptions;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {


### PR DESCRIPTION
…an be re-used to report any frontend exceptions as well. The endpoint to ingest errors is currently disabled as it's not a feature we want to support yet, but it is something we will actively look into.