### PR TITLE
Fix the type of profileUrl & schoolEmail to indicate that it can be null

### DIFF
--- a/js/src/components/ui/header/Header.tsx
+++ b/js/src/components/ui/header/Header.tsx
@@ -34,7 +34,7 @@ export default function Header() {
       const profileUrl = data.user.profileUrl;
       const initial =
         data.user.nickname ? data.user.nickname.charAt(0).toUpperCase() : "?";
-      return <AvatarButton src={profileUrl} initial={initial} />;
+      return <AvatarButton src={profileUrl ?? ""} initial={initial} />;
     }
 
     return (

--- a/src/main/java/com/patina/codebloom/common/db/models/user/PrivateUser.java
+++ b/src/main/java/com/patina/codebloom/common/db/models/user/PrivateUser.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class PrivateUser extends User {
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final String verifyKey;
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
     private String schoolEmail;
 
     public PrivateUser(

--- a/src/main/java/com/patina/codebloom/common/db/models/user/User.java
+++ b/src/main/java/com/patina/codebloom/common/db/models/user/User.java
@@ -29,7 +29,7 @@ public class User {
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean admin;
 
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
     private String profileUrl;
 
     /**


### PR DESCRIPTION
new type signature of `User`:
<img width="550" height="242" alt="image" src="https://github.com/user-attachments/assets/d0a16de9-1276-4ea2-b836-13643f48075b" />

new type signature of `PrivateUser`:
<img width="580" height="249" alt="image" src="https://github.com/user-attachments/assets/3ca8ff8a-4bc7-4b9c-b043-63e9164ad325" />

the database schema type of `User` from Dbeaver showing that `schoolEmail` can be `null` and `profileUrl` can be `null`:
<img width="825" height="201" alt="image" src="https://github.com/user-attachments/assets/bdd17765-001d-43e9-96c5-9b9116c1027b" />
