### PR TITLE
Remove announcement logic

### DIFF
--- a/db/repeated/R__Mock_v10.SQL
+++ b/db/repeated/R__Mock_v10.SQL
@@ -1,0 +1,9 @@
+DO $$ BEGIN
+INSERT INTO "Announcement" 
+    (id, "createdAt", "expiresAt", "showTimer", message)
+VALUES
+    ('a2b2D3d4-e3f6-7820-abcd-ef5432176890', NOW() - INTERVAL '5 minutes', NOW() + INTERVAL '43800 minutes',true,'testing');
+
+
+
+END $$

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.patina.codebloom.api.admin.body.CreateAnnouncementBody;
+import com.patina.codebloom.api.admin.body.DeleteAnnouncementBody;
 import com.patina.codebloom.api.admin.body.NewLeaderboardBody;
 import com.patina.codebloom.api.admin.body.UpdateAdminBody;
 import com.patina.codebloom.api.admin.helper.PatinaDiscordMessageHelper;
@@ -157,4 +158,27 @@ public class AdminController {
 
         return ResponseEntity.ok(ApiResponder.success("New announcement successfully created!", announcement));
     }
+
+    @Operation(summary = "Create a delete announcement if exist (only for admins).", responses = {
+            @ApiResponse(responseCode = "401", description = "Not authenticated", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class))),
+            @ApiResponse(responseCode = "200", description = "Announcement successfully Deleted"),
+            @ApiResponse(responseCode = "500", description = "Something went wrong", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class)))
+    })
+    @PostMapping("/announcement/delete")
+    public ResponseEntity<ApiResponder<Announcement>> deleteAnnouncement(@Valid @RequestBody final DeleteAnnouncementBody DeleteAnnouncementBody,final HttpServletRequest request) {
+        protector.validateAdminSession(request);
+        Announcement announcement = announcementRepository.getAnnouncementById(DeleteAnnouncementBody.getId());
+        if(announcement == null){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, " announcement does not exist");
+        }
+        boolean isSuccessful = announcementRepository.deleteAnnouncementById(announcement.getId());
+
+        if (!isSuccessful) {
+            return ResponseEntity
+                            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .body(ApiResponder.failure("Hmm, something went wrong."));
+        }
+         return ResponseEntity.ok(ApiResponder.success("announcement successfully deleted!", announcement));
+    }
+
 }

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -165,10 +165,10 @@ public class AdminController {
             @ApiResponse(responseCode = "500", description = "Something went wrong", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class)))
     })
     @PostMapping("/announcement/delete")
-    public ResponseEntity<ApiResponder<Announcement>> deleteAnnouncement(@Valid @RequestBody final DeleteAnnouncementBody DeleteAnnouncementBody,final HttpServletRequest request) {
+    public ResponseEntity<ApiResponder<Announcement>> deleteAnnouncement(@Valid @RequestBody final DeleteAnnouncementBody deleteAnnouncementBody, final HttpServletRequest request) {
         protector.validateAdminSession(request);
-        Announcement announcement = announcementRepository.getAnnouncementById(DeleteAnnouncementBody.getId());
-        if(announcement == null){
+        Announcement announcement = announcementRepository.getAnnouncementById(deleteAnnouncementBody.getId());
+        if (announcement == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, " announcement does not exist");
         }
         boolean isSuccessful = announcementRepository.deleteAnnouncementById(announcement.getId());
@@ -178,7 +178,7 @@ public class AdminController {
                             .status(HttpStatus.INTERNAL_SERVER_ERROR)
                             .body(ApiResponder.failure("Hmm, something went wrong."));
         }
-         return ResponseEntity.ok(ApiResponder.success("announcement successfully deleted!", announcement));
+        return ResponseEntity.ok(ApiResponder.success("announcement successfully deleted!", announcement));
     }
 
 }

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -169,7 +169,7 @@ public class AdminController {
         protector.validateAdminSession(request);
         Announcement announcement = announcementRepository.getAnnouncementById(deleteAnnouncementBody.getId());
         if (announcement == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, " announcement does not exist");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Announcement does not exist");
         }
         boolean isSuccessful = announcementRepository.deleteAnnouncementById(announcement.getId());
 

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -178,7 +178,7 @@ public class AdminController {
                             .status(HttpStatus.INTERNAL_SERVER_ERROR)
                             .body(ApiResponder.failure("Hmm, something went wrong."));
         }
-        return ResponseEntity.ok(ApiResponder.success("announcement successfully deleted!", announcement));
+        return ResponseEntity.ok(ApiResponder.success("Announcement successfully deleted!", announcement));
     }
 
 }

--- a/src/main/java/com/patina/codebloom/api/admin/body/DeleteAnnouncementBody.java
+++ b/src/main/java/com/patina/codebloom/api/admin/body/DeleteAnnouncementBody.java
@@ -1,7 +1,5 @@
 package com.patina.codebloom.api.admin.body;
 
-
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,5 +10,5 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 public class DeleteAnnouncementBody {
-	private String id;
+    private String id;
 }

--- a/src/main/java/com/patina/codebloom/api/admin/body/DeleteAnnouncementBody.java
+++ b/src/main/java/com/patina/codebloom/api/admin/body/DeleteAnnouncementBody.java
@@ -1,0 +1,16 @@
+package com.patina.codebloom.api.admin.body;
+
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class DeleteAnnouncementBody {
+	private String id;
+}


### PR DESCRIPTION
-added a repeated db migration for announcement for testing purposes
-added delete Body 
- wrote endpoint using remove announcement logic 

**DB Migration** 
<img width="1163" height="737" alt="Screenshot 2025-08-28 at 11 59 42 AM" src="https://github.com/user-attachments/assets/34a1d397-3a22-4fe3-ac8f-ac003d3e6198" />
**Announcement response after testing** 
<img width="1183" height="422" alt="Screenshot 2025-08-28 at 12 08 22 PM" src="https://github.com/user-attachments/assets/07423903-4db9-4c06-b4c3-b2a3c2084a05" />

**Database after deleting and front end**

<img width="1468" height="796" alt="Screenshot 2025-08-28 at 12 11 55 PM" src="https://github.com/user-attachments/assets/1dc7fe14-22e3-4c28-9405-a118c781a7c1" />
<img width="975" height="492" alt="Screenshot 2025-08-28 at 12 11 39 PM" src="https://github.com/user-attachments/assets/1375d185-78f7-4f9a-b456-b392a97143e2" />

