### PR TITLE
Update leetcode client + add throttled leetcode client (desc)

### DIFF
--- a/src/main/java/com/patina/codebloom/api/auth/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/patina/codebloom/api/auth/security/CustomAuthenticationSuccessHandler.java
@@ -22,6 +22,7 @@ import com.patina.codebloom.common.db.repos.user.UserRepository;
 import com.patina.codebloom.common.db.repos.usertag.UserTagRepository;
 import com.patina.codebloom.common.leetcode.LeetcodeClient;
 import com.patina.codebloom.common.leetcode.models.UserProfile;
+import com.patina.codebloom.common.leetcode.throttled.ThrottledLeetcodeClient;
 import com.patina.codebloom.common.time.StandardizedLocalDateTime;
 import com.patina.codebloom.jda.client.JDAClient;
 
@@ -55,13 +56,13 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
     public CustomAuthenticationSuccessHandler(final UserRepository userRepository, final SessionRepository sessionRepository,
                     final LeaderboardRepository leaderboardRepository,
                     final JDAClient jdaClient,
-                    final UserTagRepository userTagRepository, final LeetcodeClient leetcodeClient) {
+                    final UserTagRepository userTagRepository, final ThrottledLeetcodeClient throttledLeetcodeClient) {
         this.userRepository = userRepository;
         this.sessionRepository = sessionRepository;
         this.leaderboardRepository = leaderboardRepository;
         this.jdaClient = jdaClient.connect();
         this.userTagRepository = userTagRepository;
-        this.leetcodeClient = leetcodeClient;
+        this.leetcodeClient = throttledLeetcodeClient;
     }
 
     @Override

--- a/src/main/java/com/patina/codebloom/api/submission/SubmissionController.java
+++ b/src/main/java/com/patina/codebloom/api/submission/SubmissionController.java
@@ -32,6 +32,7 @@ import com.patina.codebloom.common.lag.FakeLag;
 import com.patina.codebloom.common.leetcode.LeetcodeClient;
 import com.patina.codebloom.common.leetcode.models.LeetcodeSubmission;
 import com.patina.codebloom.common.leetcode.models.UserProfile;
+import com.patina.codebloom.common.leetcode.throttled.ThrottledLeetcodeClient;
 import com.patina.codebloom.common.security.AuthenticationObject;
 import com.patina.codebloom.common.security.Protector;
 import com.patina.codebloom.common.simpleredis.SimpleRedis;
@@ -77,13 +78,13 @@ public class SubmissionController {
     }
 
     public SubmissionController(final UserRepository userRepository, final Protector protector, final SimpleRedis simpleRedis,
-                    final LeetcodeClient leetcodeClient,
+                    final ThrottledLeetcodeClient throttledLeetcodeClient,
                     final SubmissionsHandler submissionsHandler, final QuestionRepository questionRepository,
                     final POTDRepository potdRepository) {
         this.userRepository = userRepository;
         this.protector = protector;
         this.simpleRedis = simpleRedis;
-        this.leetcodeClient = leetcodeClient;
+        this.leetcodeClient = throttledLeetcodeClient;
         this.submissionsHandler = submissionsHandler;
         this.questionRepository = questionRepository;
         this.potdRepository = potdRepository;

--- a/src/main/java/com/patina/codebloom/common/leetcode/LeetcodeClientImpl.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/LeetcodeClientImpl.java
@@ -175,8 +175,6 @@ public class LeetcodeClientImpl implements LeetcodeClient {
             int statusCode = response.statusCode();
             String body = response.body();
 
-            System.out.println(response.headers().allValues("Set-Cookie"));
-
             if (statusCode != 200) {
                 throw new RuntimeException("API Returned status " + statusCode + ": " + body);
             }

--- a/src/main/java/com/patina/codebloom/common/leetcode/queries/GetPotd.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/queries/GetPotd.java
@@ -1,16 +1,31 @@
 package com.patina.codebloom.common.leetcode.queries;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class GetPotd {
     public static final String QUERY = """
-            #graphql
-            query questionOfToday {
-                activeDailyCodingChallengeQuestion {
-                    question {
-                        titleSlug
-                        title
-                        difficulty
+                    #graphql
+                    query questionOfToday {
+                        activeDailyCodingChallengeQuestion {
+                            question {
+                                titleSlug
+                                title
+                                difficulty
+                            }
+                        }
                     }
-                }
-            }
-            """;
+                    """;
+
+    public static String body() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("query", QUERY);
+
+        return objectMapper.writeValueAsString(requestBodyMap);
+    }
 }

--- a/src/main/java/com/patina/codebloom/common/leetcode/queries/GetSubmissionDetails.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/queries/GetSubmissionDetails.java
@@ -1,24 +1,44 @@
 package com.patina.codebloom.common.leetcode.queries;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class GetSubmissionDetails {
     public static final String QUERY = """
-            #graphql
-            query submissionDetails($submissionId: Int!) {
-                submissionDetails(submissionId: $submissionId) {
-                  runtime
-                  runtimeDisplay
-                  runtimePercentile
-                  runtimeDistribution
-                  memory
-                  memoryDisplay
-                  memoryPercentile
-                  code
-                  timestamp
-                  lang {
-                    name
-                    verboseName
-                  }
-                }
-              }
-                    """;
+                    #graphql
+                    query submissionDetails($submissionId: Int!) {
+                        submissionDetails(submissionId: $submissionId) {
+                          runtime
+                          runtimeDisplay
+                          runtimePercentile
+                          runtimeDistribution
+                          memory
+                          memoryDisplay
+                          memoryPercentile
+                          code
+                          timestamp
+                          lang {
+                            name
+                            verboseName
+                          }
+                        }
+                      }
+                            """;
+
+    public static String body(final int submissionId) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("query", QUERY);
+
+        Map<String, Integer> variables = new HashMap<>();
+        variables.put("submissionId", submissionId);
+        requestBodyMap.put("variables", variables);
+
+        return objectMapper.writeValueAsString(requestBodyMap);
+
+    }
 }

--- a/src/main/java/com/patina/codebloom/common/leetcode/queries/GetUserProfile.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/queries/GetUserProfile.java
@@ -1,5 +1,11 @@
 package com.patina.codebloom.common.leetcode.queries;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class GetUserProfile {
     public static final String QUERY = """
                     #graphql
@@ -15,4 +21,17 @@ public class GetUserProfile {
                       }
                     }
                     """;
+
+    public static String body(final String username) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("query", QUERY);
+
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("username", username);
+        requestBodyMap.put("variables", variables);
+
+        return objectMapper.writeValueAsString(requestBodyMap);
+    }
 }

--- a/src/main/java/com/patina/codebloom/common/leetcode/queries/SelectAcceptedSubmisisonsQuery.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/queries/SelectAcceptedSubmisisonsQuery.java
@@ -1,17 +1,40 @@
 package com.patina.codebloom.common.leetcode.queries;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class SelectAcceptedSubmisisonsQuery {
     public static final String QUERY = """
-            #graphql
-            query recentAcSubmissions($username: String!, $limit: Int) {
-                recentAcSubmissionList(username: $username, limit: $limit) {
-                    id
-                    title
-                    titleSlug
-                    timestamp
-                    statusDisplay
-                    lang
-                }
-            }
-            """;
+                    #graphql
+                    query recentAcSubmissions($username: String!, $limit: Int) {
+                        recentAcSubmissionList(username: $username, limit: $limit) {
+                            id
+                            title
+                            titleSlug
+                            timestamp
+                            statusDisplay
+                            lang
+                        }
+                    }
+                    """;
+
+    public static String body(final String username) throws JsonProcessingException {
+        // API doesn't let you get more than this amount.
+        int limit = 20;
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("query", QUERY);
+
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("username", username);
+        variables.put("limit", limit);
+        requestBodyMap.put("variables", variables);
+
+        return objectMapper.writeValueAsString(requestBodyMap);
+    }
 };

--- a/src/main/java/com/patina/codebloom/common/leetcode/queries/SelectProblemQuery.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/queries/SelectProblemQuery.java
@@ -1,17 +1,36 @@
 package com.patina.codebloom.common.leetcode.queries;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class SelectProblemQuery {
     public static final String QUERY = """
-            #graphql
-            query selectProblem($titleSlug: String!) {
-                question(titleSlug: $titleSlug) {
-                    questionId
-                    title
-                    titleSlug
-                    content
-                    difficulty
-                    stats
-                }
-            }
-            """;
+                    #graphql
+                    query selectProblem($titleSlug: String!) {
+                        question(titleSlug: $titleSlug) {
+                            questionId
+                            title
+                            titleSlug
+                            content
+                            difficulty
+                            stats
+                        }
+                    }
+                    """;
+
+    public static String body(final String slug) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("query", QUERY);
+
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("titleSlug", slug);
+        requestBodyMap.put("variables", variables);
+
+        return objectMapper.writeValueAsString(requestBodyMap);
+    }
 }

--- a/src/main/java/com/patina/codebloom/common/leetcode/throttled/ThrottledLeetcodeClient.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/throttled/ThrottledLeetcodeClient.java
@@ -1,0 +1,10 @@
+package com.patina.codebloom.common.leetcode.throttled;
+
+import com.patina.codebloom.common.leetcode.LeetcodeClient;
+
+/**
+ * Attaches a rate limiter over {@link LeetcodeClient} to avoid getting
+ * rate-limited from leetcode.com
+ */
+public interface ThrottledLeetcodeClient extends LeetcodeClient {
+}

--- a/src/main/java/com/patina/codebloom/common/leetcode/throttled/ThrottledLeetcodeClientImpl.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/throttled/ThrottledLeetcodeClientImpl.java
@@ -1,0 +1,55 @@
+package com.patina.codebloom.common.leetcode.throttled;
+
+import java.util.ArrayList;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.patina.codebloom.common.leetcode.LeetcodeClientImpl;
+import com.patina.codebloom.common.leetcode.models.LeetcodeDetailedQuestion;
+import com.patina.codebloom.common.leetcode.models.LeetcodeQuestion;
+import com.patina.codebloom.common.leetcode.models.LeetcodeSubmission;
+import com.patina.codebloom.common.leetcode.models.POTD;
+import com.patina.codebloom.common.leetcode.models.UserProfile;
+import com.patina.codebloom.scheduled.auth.LeetcodeAuthStealer;
+
+@Component
+public class ThrottledLeetcodeClientImpl extends LeetcodeClientImpl implements ThrottledLeetcodeClient {
+    private static final double REQUESTS_PER_SECOND = 40.0d;
+    private final RateLimiter rateLimiter;
+
+    public ThrottledLeetcodeClientImpl(final LeetcodeAuthStealer leetcodeAuthStealer) {
+        super(leetcodeAuthStealer);
+        this.rateLimiter = RateLimiter.create(REQUESTS_PER_SECOND);
+    }
+
+    @Override
+    public LeetcodeQuestion findQuestionBySlug(final String slug) {
+        rateLimiter.acquire();
+        return super.findQuestionBySlug(slug);
+    }
+
+    @Override
+    public ArrayList<LeetcodeSubmission> findSubmissionsByUsername(final String username) {
+        rateLimiter.acquire();
+        return super.findSubmissionsByUsername(username);
+    }
+
+    @Override
+    public LeetcodeDetailedQuestion findSubmissionDetailBySubmissionId(final int submissionId) {
+        rateLimiter.acquire();
+        return super.findSubmissionDetailBySubmissionId(submissionId);
+    }
+
+    @Override
+    public POTD getPotd() {
+        rateLimiter.acquire();
+        return super.getPotd();
+    }
+
+    @Override
+    public UserProfile getUserProfile(final String username) {
+        rateLimiter.acquire();
+        return super.getUserProfile(username);
+    }
+}

--- a/src/main/java/com/patina/codebloom/common/leetcode/throttled/ThrottledLeetcodeClientImpl.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/throttled/ThrottledLeetcodeClientImpl.java
@@ -15,7 +15,7 @@ import com.patina.codebloom.scheduled.auth.LeetcodeAuthStealer;
 
 @Component
 public class ThrottledLeetcodeClientImpl extends LeetcodeClientImpl implements ThrottledLeetcodeClient {
-    private static final double REQUESTS_PER_SECOND = 40.0d;
+    private static final double REQUESTS_PER_SECOND = 35.0d;
     private final RateLimiter rateLimiter;
 
     public ThrottledLeetcodeClientImpl(final LeetcodeAuthStealer leetcodeAuthStealer) {

--- a/src/main/java/com/patina/codebloom/common/submissions/SubmissionsHandler.java
+++ b/src/main/java/com/patina/codebloom/common/submissions/SubmissionsHandler.java
@@ -22,6 +22,7 @@ import com.patina.codebloom.common.leetcode.models.LeetcodeDetailedQuestion;
 import com.patina.codebloom.common.leetcode.models.LeetcodeQuestion;
 import com.patina.codebloom.common.leetcode.models.LeetcodeSubmission;
 import com.patina.codebloom.common.leetcode.score.ScoreCalculator;
+import com.patina.codebloom.common.leetcode.throttled.ThrottledLeetcodeClient;
 import com.patina.codebloom.common.submissions.object.AcceptedSubmission;
 
 /**
@@ -43,10 +44,10 @@ public class SubmissionsHandler {
         return createdAtDate.equals(today);
     }
 
-    public SubmissionsHandler(final QuestionRepository questionRepository, final LeetcodeClient leetcodeClient, final LeaderboardRepository leaderboardRepository,
+    public SubmissionsHandler(final QuestionRepository questionRepository, final ThrottledLeetcodeClient throttledLeetcodeClient, final LeaderboardRepository leaderboardRepository,
                     final POTDRepository potdRepository, final UserRepository userRepository) {
         this.questionRepository = questionRepository;
-        this.leetcodeClient = leetcodeClient;
+        this.leetcodeClient = throttledLeetcodeClient;
         this.leaderboardRepository = leaderboardRepository;
         this.potdRepository = potdRepository;
         this.userRepository = userRepository;

--- a/src/main/java/com/patina/codebloom/scheduled/leetcode/RefetchIncompleteQuestions.java
+++ b/src/main/java/com/patina/codebloom/scheduled/leetcode/RefetchIncompleteQuestions.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import com.patina.codebloom.common.db.models.question.Question;
 import com.patina.codebloom.common.db.repos.question.QuestionRepository;
 import com.patina.codebloom.common.leetcode.models.LeetcodeDetailedQuestion;
+import com.patina.codebloom.common.leetcode.throttled.ThrottledLeetcodeClient;
 import com.patina.codebloom.common.leetcode.LeetcodeClient;
 
 @Component
@@ -20,9 +21,9 @@ public class RefetchIncompleteQuestions {
     private final QuestionRepository questionRepository;
     private final LeetcodeClient leetcodeClient;
 
-    public RefetchIncompleteQuestions(final QuestionRepository questionRepository, final LeetcodeClient leetcodeClient) {
+    public RefetchIncompleteQuestions(final QuestionRepository questionRepository, final ThrottledLeetcodeClient throttledLeetcodeClient) {
         this.questionRepository = questionRepository;
-        this.leetcodeClient = leetcodeClient;
+        this.leetcodeClient = throttledLeetcodeClient;
 
     }
 

--- a/src/main/java/com/patina/codebloom/scheduled/potd/PotdSetter.java
+++ b/src/main/java/com/patina/codebloom/scheduled/potd/PotdSetter.java
@@ -10,6 +10,7 @@ import com.patina.codebloom.common.db.models.potd.POTD;
 import com.patina.codebloom.common.db.repos.potd.POTDRepository;
 import com.patina.codebloom.common.leetcode.LeetcodeClient;
 import com.patina.codebloom.common.leetcode.score.ScoreCalculator;
+import com.patina.codebloom.common.leetcode.throttled.ThrottledLeetcodeClient;
 import com.patina.codebloom.common.time.StandardizedLocalDateTime;
 
 @Component
@@ -20,8 +21,8 @@ public class PotdSetter {
     private LeetcodeClient leetcodeClient;
     private POTDRepository potdRepository;
 
-    public PotdSetter(final LeetcodeClient leetcodeClient, final POTDRepository potdRepository) {
-        this.leetcodeClient = leetcodeClient;
+    public PotdSetter(final ThrottledLeetcodeClient throttledLeetcodeClient, final POTDRepository potdRepository) {
+        this.leetcodeClient = throttledLeetcodeClient;
         this.potdRepository = potdRepository;
     }
 

--- a/src/main/java/com/patina/codebloom/scheduled/submission/SubmissionScheduler.java
+++ b/src/main/java/com/patina/codebloom/scheduled/submission/SubmissionScheduler.java
@@ -12,6 +12,7 @@ import com.patina.codebloom.common.db.models.user.User;
 import com.patina.codebloom.common.db.repos.user.UserRepository;
 import com.patina.codebloom.common.leetcode.LeetcodeClient;
 import com.patina.codebloom.common.leetcode.models.LeetcodeSubmission;
+import com.patina.codebloom.common.leetcode.throttled.ThrottledLeetcodeClient;
 import com.patina.codebloom.common.submissions.SubmissionsHandler;
 
 @Component
@@ -23,10 +24,10 @@ public class SubmissionScheduler {
     private final LeetcodeClient leetcodeClient;
     private final SubmissionsHandler submissionsHandler;
 
-    public SubmissionScheduler(final UserRepository userRepository, final LeetcodeClient leetcodeClient,
+    public SubmissionScheduler(final UserRepository userRepository, final ThrottledLeetcodeClient throttledLeetcodeClient,
                     final SubmissionsHandler submissionsHandler) {
         this.userRepository = userRepository;
-        this.leetcodeClient = leetcodeClient;
+        this.leetcodeClient = throttledLeetcodeClient;
         this.submissionsHandler = submissionsHandler;
     }
 

--- a/src/test/java/com/patina/codebloom/leetcode/LeetcodeClientTest.java
+++ b/src/test/java/com/patina/codebloom/leetcode/LeetcodeClientTest.java
@@ -156,7 +156,7 @@ public class LeetcodeClientTest {
         }
 
         if (failures.get() > 0) {
-            fail("Failed to reach 10000 requests from leetcode client. Failures: " + failures.get());
+            fail("Failed to reach 5000 requests from leetcode client. Failures: " + failures.get());
         }
     }
 }

--- a/src/test/java/com/patina/codebloom/leetcode/LeetcodeClientTest.java
+++ b/src/test/java/com/patina/codebloom/leetcode/LeetcodeClientTest.java
@@ -126,7 +126,7 @@ public class LeetcodeClientTest {
     @Test
     void stressTestConcurrent() throws InterruptedException {
         int threadCount = 100;
-        int requestsPerThread = 100;
+        int requestsPerThread = 50;
 
         Thread[] threads = new Thread[threadCount];
         AtomicInteger tries = new AtomicInteger();

--- a/src/test/java/com/patina/codebloom/leetcode/LeetcodeClientTest.java
+++ b/src/test/java/com/patina/codebloom/leetcode/LeetcodeClientTest.java
@@ -156,7 +156,7 @@ public class LeetcodeClientTest {
         }
 
         if (failures.get() > 0) {
-            fail("Failed to reach 5000 requests from leetcode client. Failures: " + failures.get());
+            fail("Failed to reach 10000 requests from leetcode client. Failures: " + failures.get());
         }
     }
 }


### PR DESCRIPTION
- Refactored LeetcodeClient to re-use one HttpClient as it is thread-safe and is able to maintain a pool of requests. 
- Refactored building the body of each request into the actual query classes so it's easier to keep track of what body is owned by what query. 
- Refactored the request builder into a private function called  which will apply defaults to each HttpRequest. 
- Created ThrottledLeetcodeClient which will force all requests to be maxed out at 35 req/s. This new class has replaced every place that is using LeetcodeClientImpl. 
- Added a new test to LeetcodeClientTest which will attempt to stress test the client by making 100 threads * 50 requests per thread = 5,000 requests, which should give us adequate breathing room without hitting any limits.