### PR TITLE
Update announcement delete to use updateAnnouncement

### DIFF
--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -171,7 +171,7 @@ public class AdminController {
         if (announcement == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Announcement does not exist");
         }
-        announcement.setShowTimer(false);
+        
         announcement.setExpiresAt(LocalDateTime.now());
         boolean updatedAnnouncement = announcementRepository.updateAnnouncement(announcement);
 

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -165,7 +165,7 @@ public class AdminController {
             @ApiResponse(responseCode = "500", description = "Something went wrong", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class)))
     })
     @PostMapping("/announcement/disable")
-    public ResponseEntity<ApiResponder<Boolean>> deleteAnnouncement(@Valid @RequestBody final DeleteAnnouncementBody deleteAnnouncementBody, final HttpServletRequest request) {
+    public ResponseEntity<ApiResponder<Empty>> deleteAnnouncement(@Valid @RequestBody final DeleteAnnouncementBody deleteAnnouncementBody, final HttpServletRequest request) {
         protector.validateAdminSession(request);
         Announcement announcement = announcementRepository.getAnnouncementById(deleteAnnouncementBody.getId());
         if (announcement == null) {
@@ -180,7 +180,7 @@ public class AdminController {
                             .status(HttpStatus.INTERNAL_SERVER_ERROR)
                             .body(ApiResponder.failure("Hmm, something went wrong."));
         }
-        return ResponseEntity.ok(ApiResponder.success("Announcement successfully disabled!", updatedAnnouncement));
+        return ResponseEntity.ok(ApiResponder.success("Announcement successfully disabled!", Empty.of()));
     }
 
 }

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -165,7 +165,7 @@ public class AdminController {
             @ApiResponse(responseCode = "500", description = "Something went wrong", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class)))
     })
     @PostMapping("/announcement/disable")
-    public ResponseEntity<ApiResponder<Announcement>> deleteAnnouncement(@Valid @RequestBody final DeleteAnnouncementBody deleteAnnouncementBody, final HttpServletRequest request) {
+    public ResponseEntity<ApiResponder<Boolean>> deleteAnnouncement(@Valid @RequestBody final DeleteAnnouncementBody deleteAnnouncementBody, final HttpServletRequest request) {
         protector.validateAdminSession(request);
         Announcement announcement = announcementRepository.getAnnouncementById(deleteAnnouncementBody.getId());
         if (announcement == null) {
@@ -173,9 +173,9 @@ public class AdminController {
         }
         announcement.setShowTimer(false);
         announcement.setExpiresAt(LocalDateTime.now());
-        Announcement updatedAnnouncement = announcementRepository.updateAnnouncement(announcement);
+        boolean updatedAnnouncement = announcementRepository.updateAnnouncement(announcement);
 
-        if (updatedAnnouncement == null) {
+        if (!updatedAnnouncement) {
             return ResponseEntity
                             .status(HttpStatus.INTERNAL_SERVER_ERROR)
                             .body(ApiResponder.failure("Hmm, something went wrong."));

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -164,21 +164,23 @@ public class AdminController {
             @ApiResponse(responseCode = "200", description = "Announcement successfully Deleted"),
             @ApiResponse(responseCode = "500", description = "Something went wrong", content = @Content(schema = @Schema(implementation = UnsafeGenericFailureResponse.class)))
     })
-    @PostMapping("/announcement/delete")
+    @PostMapping("/announcement/disable")
     public ResponseEntity<ApiResponder<Announcement>> deleteAnnouncement(@Valid @RequestBody final DeleteAnnouncementBody deleteAnnouncementBody, final HttpServletRequest request) {
         protector.validateAdminSession(request);
         Announcement announcement = announcementRepository.getAnnouncementById(deleteAnnouncementBody.getId());
         if (announcement == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Announcement does not exist");
         }
-        boolean isSuccessful = announcementRepository.deleteAnnouncementById(announcement.getId());
+        announcement.setShowTimer(false);
+        announcement.setExpiresAt(LocalDateTime.now());
+        Announcement updatedAnnouncement = announcementRepository.updateAnnouncement(announcement);
 
-        if (!isSuccessful) {
+        if (updatedAnnouncement == null) {
             return ResponseEntity
                             .status(HttpStatus.INTERNAL_SERVER_ERROR)
                             .body(ApiResponder.failure("Hmm, something went wrong."));
         }
-        return ResponseEntity.ok(ApiResponder.success("Announcement successfully deleted!", announcement));
+        return ResponseEntity.ok(ApiResponder.success("Announcement successfully disabled!", updatedAnnouncement));
     }
 
 }

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -170,7 +170,7 @@ public class AdminController {
         Announcement announcement = announcementRepository.getAnnouncementById(deleteAnnouncementBody.getId());
         if (announcement == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Announcement does not exist");
-        }        
+        }
         announcement.setExpiresAt(LocalDateTime.now());
         boolean updatedAnnouncement = announcementRepository.updateAnnouncement(announcement);
 

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -170,8 +170,7 @@ public class AdminController {
         Announcement announcement = announcementRepository.getAnnouncementById(deleteAnnouncementBody.getId());
         if (announcement == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Announcement does not exist");
-        }
-        
+        }        
         announcement.setExpiresAt(LocalDateTime.now());
         boolean updatedAnnouncement = announcementRepository.updateAnnouncement(announcement);
 

--- a/src/main/java/com/patina/codebloom/common/db/models/announcement/Announcement.java
+++ b/src/main/java/com/patina/codebloom/common/db/models/announcement/Announcement.java
@@ -12,6 +12,7 @@ import lombok.ToString;
 
 @Builder
 @Getter
+@Setter
 @ToString
 @EqualsAndHashCode
 public class Announcement {
@@ -19,10 +20,10 @@ public class Announcement {
     // so we can override id property when new object
     // created in database.
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-    private @Setter String id;
+    private String id;
 
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-    private @Setter LocalDateTime createdAt;
+    private LocalDateTime createdAt;
 
     @NotNull
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/patina/codebloom/common/db/models/announcement/Announcement.java
+++ b/src/main/java/com/patina/codebloom/common/db/models/announcement/Announcement.java
@@ -16,9 +16,7 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public class Announcement {
-    // @Setter on some of the properties
-    // so we can override id property when new object
-    // created in database.
+    
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private String id;
 

--- a/src/main/java/com/patina/codebloom/common/db/models/announcement/Announcement.java
+++ b/src/main/java/com/patina/codebloom/common/db/models/announcement/Announcement.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public class Announcement {
-    
+
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private String id;
 

--- a/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementRepository.java
+++ b/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementRepository.java
@@ -20,5 +20,5 @@ public interface AnnouncementRepository {
 
     boolean deleteAnnouncementById(String id);
 
-    Announcement updateAnnouncement(Announcement announcement);
+    boolean updateAnnouncement(Announcement announcement);
 }

--- a/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementRepository.java
+++ b/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementRepository.java
@@ -19,4 +19,6 @@ public interface AnnouncementRepository {
     boolean createAnnouncement(Announcement announcement);
 
     boolean deleteAnnouncementById(String id);
+
+    Announcement updateAnnouncement(Announcement announcement);
 }

--- a/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementSqlRepository.java
+++ b/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementSqlRepository.java
@@ -170,7 +170,7 @@ public class AnnouncementSqlRepository implements AnnouncementRepository {
     }
 
     @Override
-    public Announcement updateAnnouncement(final Announcement announcement) {
+    public boolean updateAnnouncement(final Announcement announcement) {
         String sql = """
                         UPDATE
                             "Announcement"
@@ -186,8 +186,8 @@ public class AnnouncementSqlRepository implements AnnouncementRepository {
             stmt.setBoolean("showTimer", announcement.isShowTimer());
             stmt.setString("message", announcement.getMessage());
             stmt.setObject("id", UUID.fromString(announcement.getId()));
-            stmt.executeUpdate();
-            return getAnnouncementById(announcement.getId());
+            int rowsAffected = stmt.executeUpdate();
+            return rowsAffected > 0;
 
         } catch (SQLException e) {
             throw new RuntimeException("Failed to update announcement", e);

--- a/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementSqlRepository.java
+++ b/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementSqlRepository.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Component;
 
 import com.patina.codebloom.common.db.DbConnection;
+import com.patina.codebloom.common.db.helper.NamedPreparedStatement;
 import com.patina.codebloom.common.db.models.announcement.Announcement;
 
 @Component
@@ -166,5 +167,31 @@ public class AnnouncementSqlRepository implements AnnouncementRepository {
         } catch (SQLException e) {
             throw new RuntimeException("Failed to delete announcement by ID", e);
         }
+    }
+
+    @Override
+    public Announcement updateAnnouncement(final Announcement announcement) {
+        String sql = """
+                        UPDATE
+                            "Announcement"
+                        SET
+                            "expiresAt" = :expiresAt,
+                            "showTimer" = :showTimer,
+                            "message"  = :message
+                        WHERE
+                            id = :id
+                        """;
+        try (NamedPreparedStatement stmt = new NamedPreparedStatement(conn, sql)) {
+            stmt.setObject("expiresAt", announcement.getExpiresAt());
+            stmt.setBoolean("showTimer", announcement.isShowTimer());
+            stmt.setString("message", announcement.getMessage());
+            stmt.setObject("id", UUID.fromString(announcement.getId()));
+            stmt.executeUpdate();
+            return getAnnouncementById(announcement.getId());
+
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to update achievement", e);
+        }
+
     }
 }

--- a/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementSqlRepository.java
+++ b/src/main/java/com/patina/codebloom/common/db/repos/announcement/AnnouncementSqlRepository.java
@@ -190,7 +190,7 @@ public class AnnouncementSqlRepository implements AnnouncementRepository {
             return getAnnouncementById(announcement.getId());
 
         } catch (SQLException e) {
-            throw new RuntimeException("Failed to update achievement", e);
+            throw new RuntimeException("Failed to update announcement", e);
         }
 
     }

--- a/src/test/java/com/patina/codebloom/db/announcement/AnnouncementRepositoryTest.java
+++ b/src/test/java/com/patina/codebloom/db/announcement/AnnouncementRepositoryTest.java
@@ -112,13 +112,13 @@ public class AnnouncementRepositoryTest {
                         .id(testAnnouncement.getId())
                         .expiresAt(testAnnouncement.getExpiresAt())
                         .showTimer(true)
-                        .message("Hi this is a update announcement!")
+                        .message("Hi this is an update announcement!")
                         .build();
 
         Announcement result = announcementRepository.updateAnnouncement(updatedAnnouncement);
 
         assertNotNull(result);
-        assertEquals(result.getMessage(), "Hi this is a update announcement!");
+        assertEquals(result.getMessage(), "Hi this is an update announcement!");
         assertEquals(result.getId(), testAnnouncement.getId());
         assertTrue(result.isShowTimer());
     }

--- a/src/test/java/com/patina/codebloom/db/announcement/AnnouncementRepositoryTest.java
+++ b/src/test/java/com/patina/codebloom/db/announcement/AnnouncementRepositoryTest.java
@@ -89,7 +89,7 @@ public class AnnouncementRepositoryTest {
     }
 
     @Test
-    @Order(3)
+    @Order(2)
     void findAnnouncementById() {
         Announcement possibleTestAnnouncement = announcementRepository.getAnnouncementById(testAnnouncement.getId());
 
@@ -100,13 +100,13 @@ public class AnnouncementRepositoryTest {
         log.info("testAnnouncement: {}", testAnnouncement.toString());
         log.info("possibleTestAnnouncement: {}", possibleTestAnnouncement.toString());
 
-        if (!testAnnouncement.getId().equals(possibleTestAnnouncement.getId())) {
-            fail("the generated test announcement ID does not match the announcement fetched with get announcement by ID");
-        }
+       if (!testAnnouncement.equals(possibleTestAnnouncement)) {
+            fail("the generated test announcement does not match the announcement fetched with get announcement by ID");
+       }
     }
 
     @Test
-    @Order(2)
+    @Order(4)
     void updateAnnouncementTest() {
         Announcement updatedAnnouncement = Announcement.builder()
                         .id(testAnnouncement.getId())
@@ -114,17 +114,19 @@ public class AnnouncementRepositoryTest {
                         .showTimer(true)
                         .message("Hi this is an update announcement!")
                         .build();
-
-        Announcement result = announcementRepository.updateAnnouncement(updatedAnnouncement);
-
-        assertNotNull(result);
-        assertEquals(result.getMessage(), "Hi this is an update announcement!");
-        assertEquals(result.getId(), testAnnouncement.getId());
-        assertTrue(result.isShowTimer());
+        boolean result = announcementRepository.updateAnnouncement(updatedAnnouncement);
+        if (!result){
+            fail("failure to update announcement");
+        }
+        Announcement resultAnnouncement = announcementRepository.getAnnouncementById(updatedAnnouncement.getId());
+        assertNotNull(resultAnnouncement);
+        assertEquals(resultAnnouncement.getMessage(), "Hi this is an update announcement!");
+        assertEquals(resultAnnouncement.getId(), testAnnouncement.getId());
+        assertTrue(resultAnnouncement.isShowTimer());
     }
 
     @Test
-    @Order(4)
+    @Order(3)
     void findAllAnnouncements() {
         List<Announcement> announcementsList = announcementRepository.getAllAnnouncements();
 
@@ -138,9 +140,7 @@ public class AnnouncementRepositoryTest {
 
         log.info(announcementsList.toString());
 
-        boolean foundTestAnnouncement = announcementsList.stream()
-                        .anyMatch(announcement -> announcement.getId().equals(testAnnouncement.getId()));
-        if (!foundTestAnnouncement) {
+         if (!announcementsList.contains(testAnnouncement)) {
             fail("test announcement cannot be found in the list of all announcements");
         }
     }

--- a/src/test/java/com/patina/codebloom/db/announcement/AnnouncementRepositoryTest.java
+++ b/src/test/java/com/patina/codebloom/db/announcement/AnnouncementRepositoryTest.java
@@ -1,8 +1,9 @@
 package com.patina.codebloom.db.announcement;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -88,6 +89,7 @@ public class AnnouncementRepositoryTest {
     }
 
     @Test
+    @Order(3)
     void findAnnouncementById() {
         Announcement possibleTestAnnouncement = announcementRepository.getAnnouncementById(testAnnouncement.getId());
 
@@ -98,12 +100,31 @@ public class AnnouncementRepositoryTest {
         log.info("testAnnouncement: {}", testAnnouncement.toString());
         log.info("possibleTestAnnouncement: {}", possibleTestAnnouncement.toString());
 
-        if (!testAnnouncement.equals(possibleTestAnnouncement)) {
-            fail("the generated test announcement does not match the announcement fetched with get announcement by ID");
+        if (!testAnnouncement.getId().equals(possibleTestAnnouncement.getId())) {
+            fail("the generated test announcement ID does not match the announcement fetched with get announcement by ID");
         }
     }
 
     @Test
+    @Order(2)
+    void updateAnnouncementTest() {
+        Announcement updatedAnnouncement = Announcement.builder()
+                        .id(testAnnouncement.getId())
+                        .expiresAt(testAnnouncement.getExpiresAt())
+                        .showTimer(true)
+                        .message("Hi this is a update announcement!")
+                        .build();
+
+        Announcement result = announcementRepository.updateAnnouncement(updatedAnnouncement);
+
+        assertNotNull(result);
+        assertEquals(result.getMessage(), "Hi this is a update announcement!");
+        assertEquals(result.getId(), testAnnouncement.getId());
+        assertTrue(result.isShowTimer());
+    }
+
+    @Test
+    @Order(4)
     void findAllAnnouncements() {
         List<Announcement> announcementsList = announcementRepository.getAllAnnouncements();
 
@@ -116,9 +137,11 @@ public class AnnouncementRepositoryTest {
         }
 
         log.info(announcementsList.toString());
-        if (!announcementsList.contains(testAnnouncement)) {
+
+        boolean foundTestAnnouncement = announcementsList.stream()
+                        .anyMatch(announcement -> announcement.getId().equals(testAnnouncement.getId()));
+        if (!foundTestAnnouncement) {
             fail("test announcement cannot be found in the list of all announcements");
         }
     }
-
 }


### PR DESCRIPTION
-added update announcement in announcement sql repo and repo
- added update announcement test and fixed logic of other test functions
- added new logic for admin controller 
- addes setter to all announcements
**Before**
<img width="1030" height="603" alt="Screenshot 2025-09-03 at 11 22 21 AM" src="https://github.com/user-attachments/assets/04bb6551-e3ef-40d7-9451-8560f8dad8cd" />

**RESPONSE from Admin Controller**
<img width="1270" height="442" alt="Screenshot 2025-09-03 at 11 23 17 AM" src="https://github.com/user-attachments/assets/5a7f4c48-d259-42f6-825b-894285af1a43" />

**DB AFTER**
<img width="1162" height="533" alt="Screenshot 2025-09-03 at 11 24 28 AM" src="https://github.com/user-attachments/assets/8bf33c44-bc14-4cc3-97cf-5f1b1ea14196" />
