### PR TITLE
Fix announ time

### DIFF
--- a/js/src/app/admin/_components/announcements/NewAnnouncementModal.tsx
+++ b/js/src/app/admin/_components/announcements/NewAnnouncementModal.tsx
@@ -20,7 +20,7 @@ export default function NewAnnouncementModal() {
     },
     transformValues: ({ expiresAt, ...values }) => ({
       ...values,
-      expiresAt: d(expiresAt).toISOString(),
+      expiresAt: d(expiresAt).format("YYYY-MM-DDTHH:mm:ss"),
     }),
   });
 

--- a/src/main/java/com/patina/codebloom/api/admin/AdminController.java
+++ b/src/main/java/com/patina/codebloom/api/admin/AdminController.java
@@ -25,6 +25,7 @@ import com.patina.codebloom.common.dto.ApiResponder;
 import com.patina.codebloom.common.dto.Empty;
 import com.patina.codebloom.common.dto.autogen.UnsafeGenericFailureResponse;
 import com.patina.codebloom.common.security.Protector;
+import com.patina.codebloom.common.time.StandardizedLocalDateTime;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -136,7 +137,7 @@ public class AdminController {
                     final HttpServletRequest request) {
         protector.validateAdminSession(request);
 
-        boolean isInFuture = LocalDateTime.now().isBefore(createAnnouncementBody.getExpiresAt());
+        boolean isInFuture = StandardizedLocalDateTime.now().isBefore(createAnnouncementBody.getExpiresAt());
 
         if (!isInFuture) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The expiration date must be in the future.");


### PR DESCRIPTION
after some testing, i noticed the frontend was converting the local time to UTC before sending it to the backend by using '.toISOString()' which automatically applies the timezone conversions. 

my solution:
i changed the frontend date time formatting to YYYY-MM-DDTHH:mm:ss to preserve the local time since AdminController was using LocalDateTIme.now()

++but i updated it to StandardizedLocalDateTime.now() for consistency with AnnouncementController

the 24 hour time count down:

https://github.com/user-attachments/assets/fb514486-633f-4da0-9983-b027e476eb1b

