### PR TITLE
Replace Guava's RateLimiter with Bucket4J's Bucket API, which is much…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-core</artifactId>
+            <version>8.15.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
             <version>10.21.2</version>

--- a/src/main/java/com/patina/codebloom/common/leetcode/throttled/ThrottledLeetcodeClientImpl.java
+++ b/src/main/java/com/patina/codebloom/common/leetcode/throttled/ThrottledLeetcodeClientImpl.java
@@ -1,10 +1,10 @@
 package com.patina.codebloom.common.leetcode.throttled;
 
+import java.time.Duration;
 import java.util.ArrayList;
 
 import org.springframework.stereotype.Component;
 
-import com.google.common.util.concurrent.RateLimiter;
 import com.patina.codebloom.common.leetcode.LeetcodeClientImpl;
 import com.patina.codebloom.common.leetcode.models.LeetcodeDetailedQuestion;
 import com.patina.codebloom.common.leetcode.models.LeetcodeQuestion;
@@ -13,43 +13,67 @@ import com.patina.codebloom.common.leetcode.models.POTD;
 import com.patina.codebloom.common.leetcode.models.UserProfile;
 import com.patina.codebloom.scheduled.auth.LeetcodeAuthStealer;
 
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BlockingBucket;
+import io.github.bucket4j.Bucket;
+
 @Component
 public class ThrottledLeetcodeClientImpl extends LeetcodeClientImpl implements ThrottledLeetcodeClient {
-    private static final double REQUESTS_PER_SECOND = 35.0d;
-    private final RateLimiter rateLimiter;
+    private static final long REQUESTS_OVER_TIME = 1L;
+    private static final long MILLISECONDS_TO_WAIT = 50L;
+    private final BlockingBucket rateLimiter;
+
+    private BlockingBucket initializeBucket() {
+        var bandwidth = Bandwidth.builder()
+                        .capacity(REQUESTS_OVER_TIME)
+                        .refillIntervally(REQUESTS_OVER_TIME, Duration.ofMillis(MILLISECONDS_TO_WAIT))
+                        .build();
+
+        return Bucket.builder()
+                        .addLimit(bandwidth)
+                        .build().asBlocking();
+    }
+
+    private void waitForToken() {
+        try {
+            rateLimiter.consume(1);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Failed to consume rate limit bucket token in leetcode client", e);
+        }
+    }
 
     public ThrottledLeetcodeClientImpl(final LeetcodeAuthStealer leetcodeAuthStealer) {
         super(leetcodeAuthStealer);
-        this.rateLimiter = RateLimiter.create(REQUESTS_PER_SECOND);
+        this.rateLimiter = initializeBucket();
     }
 
     @Override
     public LeetcodeQuestion findQuestionBySlug(final String slug) {
-        rateLimiter.acquire();
+        waitForToken();
         return super.findQuestionBySlug(slug);
     }
 
     @Override
     public ArrayList<LeetcodeSubmission> findSubmissionsByUsername(final String username) {
-        rateLimiter.acquire();
+        waitForToken();
         return super.findSubmissionsByUsername(username);
     }
 
     @Override
     public LeetcodeDetailedQuestion findSubmissionDetailBySubmissionId(final int submissionId) {
-        rateLimiter.acquire();
+        waitForToken();
         return super.findSubmissionDetailBySubmissionId(submissionId);
     }
 
     @Override
     public POTD getPotd() {
-        rateLimiter.acquire();
+        waitForToken();
         return super.getPotd();
     }
 
     @Override
     public UserProfile getUserProfile(final String username) {
-        rateLimiter.acquire();
+        waitForToken();
         return super.getUserProfile(username);
     }
 }


### PR DESCRIPTION
… more comprehensive & granular. The effective req/s has now dropped from 35 req/s to 20 req/s