### PR TITLE
Removed duplicate leetcodeUsername for user table

### DIFF
--- a/db/repeated/R__Mock_v11_Remove_duplicate_leetcodeUsername.SQL
+++ b/db/repeated/R__Mock_v11_Remove_duplicate_leetcodeUsername.SQL
@@ -1,0 +1,13 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM "User"
+        WHERE id = '5a953746-f635-4f72-98ed-ffcd5763225f'
+        AND "leetcodeUsername" = 'lucas_brown'
+    ) THEN
+        UPDATE "User"
+        SET "leetcodeUsername" = 'laura_michaelson'
+        WHERE id = '5a953746-f635-4f72-98ed-ffcd5763225f';
+    END IF;
+
+END $$;


### PR DESCRIPTION
- created repeated migration to rename a duplicate leetcodeUsername in users table
- first two images show lucas_brown as a leetcodeUsername twice in the db
- next two images show lucas_brown once, as
<img width="1470" height="956" alt="Screenshot 2025-09-17 at 1 11 26 AM" src="https://github.com/user-attachments/assets/349435e1-a6af-4455-8074-5fe15c46660f" />
<img width="1470" height="956" alt="Screenshot 2025-09-17 at 1 11 30 AM" src="https://github.com/user-attachments/assets/2acc52ae-6dda-4215-9cc4-d097519c4d24" />
<img width="1470" height="956" alt="Screenshot 2025-09-17 at 1 13 15 AM" src="https://github.com/user-attachments/assets/ddb5f5d7-b559-4af7-bf93-b1f5704be6ff" />
<img width="1470" height="956" alt="Screenshot 2025-09-17 at 1 14 46 AM" src="https://github.com/user-attachments/assets/3483f057-00c7-4330-b81c-0914a865f54c" />
 the other was change to laura_michaelson
- 