### PR TITLE
Add script to copy data from production db to staging db and scrub/drop any sensitive information

### DIFF
--- a/infra/copy-prod-db.sh
+++ b/infra/copy-prod-db.sh
@@ -14,22 +14,20 @@ echo "Cleaning staging database..."
 ./mvnw flyway:clean -Dflyway.cleanDisabled=false
 
 echo "Copying production database to staging..."
-pg_dump \
+PGPASSWORD="$DATABASE_PASSWORD" pg_dump \
     --host="$DATABASE_HOST" \
     --port="$DATABASE_PORT" \
     --username="$DATABASE_USER" \
     --dbname="$PRODUCTION_DATABASE_NAME" \
-    --no-password \
     --verbose \
     --clean \
     --if-exists \
     --format=custom |
-    pg_restore \
+    PGPASSWORD="$DATABASE_PASSWORD" pg_restore \
         --host="$DATABASE_HOST" \
         --port="$DATABASE_PORT" \
         --username="$DATABASE_USER" \
         --dbname="$STAGING_DATABASE_NAME" \
-        --no-password \
         --verbose \
         --clean \
         --if-exists

--- a/infra/copy-prod-db.sh
+++ b/infra/copy-prod-db.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+# TODO clean up for CI/command use.
+
 # Environment variables required:
 # DATABASE_HOST, DATABASE_PORT, DATABASE_USER, DATABASE_PASSWORD
 # PRODUCTION_DATABASE_NAME, STAGING_DATABASE_NAME

--- a/infra/copy-prod-db.sh
+++ b/infra/copy-prod-db.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Environment variables required:
+# DATABASE_HOST, DATABASE_PORT, DATABASE_USER, DATABASE_PASSWORD
+# PRODUCTION_DATABASE_NAME, STAGING_DATABASE_NAME
+
+# may need libpq
+# brew install libpq
+
+export DATABASE_NAME="$STAGING_DATABASE_NAME"
+
+echo "Cleaning staging database..."
+./mvnw flyway:clean -Dflyway.cleanDisabled=false
+
+echo "Copying production database to staging..."
+pg_dump \
+    --host="$DATABASE_HOST" \
+    --port="$DATABASE_PORT" \
+    --username="$DATABASE_USER" \
+    --dbname="$PRODUCTION_DATABASE_NAME" \
+    --no-password \
+    --verbose \
+    --clean \
+    --if-exists \
+    --format=custom |
+    pg_restore \
+        --host="$DATABASE_HOST" \
+        --port="$DATABASE_PORT" \
+        --username="$DATABASE_USER" \
+        --dbname="$STAGING_DATABASE_NAME" \
+        --no-password \
+        --verbose \
+        --clean \
+        --if-exists
+
+echo "Cleaning unnecessary data..."
+PGPASSWORD="$DATABASE_PASSWORD" psql \
+    --host="$DATABASE_HOST" \
+    --port="$DATABASE_PORT" \
+    --username="$DATABASE_USER" \
+    --dbname="$STAGING_DATABASE_NAME" \
+    --command="
+    DELETE FROM \"ApiKey\";
+    DELETE FROM \"Auth\";
+    DELETE FROM \"Club\";
+    DELETE FROM \"Session\";
+    
+    -- Scramble non-admin user data
+    UPDATE \"User\" 
+    SET 
+      \"nickname\" = CASE 
+        WHEN \"nickname\" IS NOT NULL THEN 'user_' || encode(gen_random_bytes(8), 'hex')
+        ELSE NULL 
+      END,
+      \"verifyKey\" = encode(gen_random_bytes(16), 'hex'),
+      \"schoolEmail\" = CASE 
+        WHEN \"schoolEmail\" IS NOT NULL THEN 'test_' || encode(gen_random_bytes(4), 'hex') || '@example.com'
+        ELSE NULL 
+      END,
+      \"profileUrl\" = 'https://via.placeholder.com/150'
+    WHERE \"admin\" IS NOT TRUE;
+  "
+
+echo "Database copy completed successfully!"


### PR DESCRIPTION
the script drops:
- `AuthKey`,
-  `Auth`,
-  `Club`,
-  `Session`. 

it also modifies all rows inside of `User` that are have `admin = false` and scrubs:
- `nickname`,
-  `verifyKey`,
-  `schoolEmail`
-  `profileUrl`. 

I chose not to scrub `discordId`, `discordName`, or `leetcodeUsername` because they aren't considered sensitive or private anyways. 

Testing:

Copied production data to a local database instance, and attempting to copy it to another local database instance (that was empty).

.env
```
DATABASE_HOST=localhost
DATABASE_PORT=5432
PRODUCTION_DATABASE_NAME=codebloom-prod-copy-sep-20
STAGING_DATABASE_NAME=codebloom-stg-2
DATABASE_USER=postgres
DATABASE_PASSWORD=passwordnomas
```

command:
```
dotenvx run -f infra/.env -- ./infra/copy-prod-db.sh
```

output: 
[output.txt](https://github.com/user-attachments/files/22449082/output.txt)
