### PR TITLE
HOTFIX: Fix Object.typedEntries not being registered properly to the …

### DIFF
--- a/js/src/main.tsx
+++ b/js/src/main.tsx
@@ -1,6 +1,7 @@
 import BannerParent from "@/components/ui/banner/BannerParent";
 import ReactQueryProvider from "@/lib/queryProvider";
 import "@mantine/core/styles.css";
+import "@/lib/helper/entries";
 import { router } from "@/lib/router";
 import { themeOverride } from "@/lib/theme";
 import "@mantine/notifications/styles.css";


### PR DESCRIPTION
…Object prototype. By adding a side-effect import, this issue is now fixed

before:
<img width="3764" height="2440" alt="image" src="https://github.com/user-attachments/assets/93e33bac-d926-4890-94ee-98c0dd771762" />



after:
<img width="1882" height="1220" alt="image" src="https://github.com/user-attachments/assets/32c9a2a1-21ef-4990-b5a5-9e0fe8c29573" />
