### PR TITLE
Added icon placement update to previous leaderboards

### DIFF
--- a/js/src/app/leaderboard/[leaderboardId]/_components/LeaderboardWithId.tsx
+++ b/js/src/app/leaderboard/[leaderboardId]/_components/LeaderboardWithId.tsx
@@ -283,8 +283,8 @@ export default function LeaderboardWithId({
                         to={`/user/${entry.id}`}
                         className="group"
                       >
-                        <Flex align="center" gap="xs">
-                          {entry.nickname ?
+                        {entry.nickname && (
+                          <Flex align="center" gap="xs">
                             <Tooltip
                               label={
                                 "This user is a verified member of the Patina Discord server."
@@ -301,11 +301,13 @@ export default function LeaderboardWithId({
                                 {entry.nickname}
                               </span>
                             </Tooltip>
-                          : <span className="transition-all group-hover:text-blue-500 w-max">
-                              <FaDiscord style={{ display: "inline" }} />{" "}
-                              {entry.discordName}
-                            </span>
-                          }
+                          </Flex>
+                        )}
+                        <Flex align="center" gap="xs">
+                          <span className="transition-all group-hover:text-blue-500 w-max">
+                            <FaDiscord style={{ display: "inline" }} />{" "}
+                            {entry.discordName}
+                          </span>
                           {tagFF && (
                             <TagList
                               tags={entry.tags || []}


### PR DESCRIPTION
- Added the format where if nickname's present, display the nickname, discord username with icons, and leetcode username and if nickname's not present then display discord username with icons and leetcode username to previous leaderboards
<img width="1470" height="872" alt="Screenshot 2025-09-22 at 10 45 13 PM" src="https://github.com/user-attachments/assets/2eb4050e-b0e2-4596-9190-7fcb94bd867d" />
