### PR TITLE
Added the default Mantine font selection ordering to school template

### DIFF
--- a/email/emails/school-email.tsx
+++ b/email/emails/school-email.tsx
@@ -19,11 +19,17 @@ import {
 type SchoolEmailProps = {
   linkUrl: string;
 };
+
 export default function SchoolEmail({
   linkUrl = "https://codebloom.patinanetwork.org",
 }: SchoolEmailProps) {
   return (
-    <Html>
+    <Html
+      style={{
+        fontFamily:
+          "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+      }}
+    >
       <Head />
       <Preview>Confirm your email to activate your CodeBloom account</Preview>
       <Tailwind>


### PR DESCRIPTION
before:
<img width="569" height="534" alt="image" src="https://github.com/user-attachments/assets/4fce24a6-6d39-4a47-8749-aecf4ac62cfb" />


after:
<img width="636" height="795" alt="image" src="https://github.com/user-attachments/assets/e8c95ca0-179f-4315-8e41-aa6323eb04ea" />
