### PR TITLE
Centered POTD title on desktop and mobile

### DIFF
--- a/js/src/app/dashboard/_components/ProblemOfTheDay/ProblemOfTheDay.tsx
+++ b/js/src/app/dashboard/_components/ProblemOfTheDay/ProblemOfTheDay.tsx
@@ -70,7 +70,9 @@ export default function ProblemOfTheDay() {
   return (
     <Card withBorder padding={"md"} radius={"md"} miw={"31vw"} mih={"63vh"}>
       <Center>
-        <Title order={3}>Problem of the day</Title>
+        <Title style={{ textAlign: "center" }} order={3}>
+          Problem of the day
+        </Title>
       </Center>
       <Center>
         <Title order={6}> POTD resets at 8:00 EDT everyday</Title>
@@ -83,7 +85,9 @@ export default function ProblemOfTheDay() {
         w={"100%"}
         h={"100%"}
       >
-        <Title order={4}>{json.title}</Title>
+        <Title style={{ textAlign: "center" }} order={4}>
+          {json.title}
+        </Title>
         <Badge
           variant={"gradient"}
           gradient={{ from: "blue.8", to: "green.8" }}


### PR DESCRIPTION
- centered POTD title and header on mobile and desktop
<img width="454" height="483" alt="Screenshot 2025-10-17 at 7 50 34 PM" src="https://github.com/user-attachments/assets/c9d0e182-ba50-4777-a4c2-fd8728da6c74" />
<img width="367" height="662" alt="Screenshot 2025-10-17 at 7 50 58 PM" src="https://github.com/user-attachments/assets/ea039be2-42f9-4c41-84a2-5e0309b5da50" />
