### PR TITLE
Fix regression where global leaderboard index switch was not in the query key, hence not refetching on change

### DIFF
--- a/js/src/lib/api/queries/leaderboard/index.ts
+++ b/js/src/lib/api/queries/leaderboard/index.ts
@@ -82,7 +82,15 @@ export const useCurrentLeaderboardUsersQuery = (
   }, [goTo, setGlobalIndex]);
 
   const query = useQuery({
-    queryKey: ["leaderboard", "users", page, pageSize, debouncedQuery, filters],
+    queryKey: [
+      "leaderboard",
+      "users",
+      page,
+      pageSize,
+      debouncedQuery,
+      filters,
+      globalIndex,
+    ],
     queryFn: () =>
       fetchLeaderboardUsers({
         page,


### PR DESCRIPTION
before where toggling does not trigger a re-fetch:
<img width="1771" height="647" alt="image" src="https://github.com/user-attachments/assets/f1ed918c-3905-4cf3-92a9-27c059065a68" />
<img width="1750" height="654" alt="image" src="https://github.com/user-attachments/assets/199ba3a2-7395-4657-ad86-df6d5a4bc6d4" />


after:
<img width="1797" height="646" alt="image" src="https://github.com/user-attachments/assets/597832bb-b70f-4ab1-ac2d-624cb1060846" />
