### PR TITLE
fixing why auth goes offline if leetcode is down

### DIFF
--- a/src/main/java/com/patina/codebloom/api/auth/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/patina/codebloom/api/auth/security/CustomAuthenticationSuccessHandler.java
@@ -92,7 +92,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
                         if (profile != null && profile.getUserAvatar() != null) {
                             existingUser.setProfileUrl(profile.getUserAvatar());
                         }
-                    } catch (Exception ex) {
+                    } catch (RuntimeException ex) {
                         LOGGER.warn("LeetCode lookup failed for {}", existingUser.getLeetcodeUsername(), ex);
                     }
                 }


### PR DESCRIPTION
- the current code -> when we hit leetcode api and leetcode is down, it throws an expection but we dont catch it, which escapes to trying to create a session 
- updated code to catch the error and still allow users to catch the session