### PR TITLE
Fix copy-prod-db.sh to a) fix any new DiscordClub entries we have for…

### DIFF
--- a/infra/copy-prod-db.sh
+++ b/infra/copy-prod-db.sh
@@ -24,15 +24,15 @@ PGPASSWORD="$DATABASE_PASSWORD" pg_dump \
     --verbose \
     --clean \
     --if-exists \
-    --format=custom |
-    PGPASSWORD="$DATABASE_PASSWORD" pg_restore \
+    --format=plain \
+    | sed '/SET transaction_timeout/d' \
+    | PGPASSWORD="$DATABASE_PASSWORD" psql \
         --host="$DATABASE_HOST" \
         --port="$DATABASE_PORT" \
         --username="$DATABASE_USER" \
         --dbname="$STAGING_DATABASE_NAME" \
-        --verbose \
-        --clean \
-        --if-exists
+        --echo-errors \
+        --single-transaction
 
 echo "Cleaning unnecessary data..."
 PGPASSWORD="$DATABASE_PASSWORD" psql \
@@ -60,6 +60,15 @@ PGPASSWORD="$DATABASE_PASSWORD" psql \
       END,
       \"profileUrl\" = 'https://via.placeholder.com/150'
     WHERE \"admin\" IS NOT TRUE;
+
+    -- Update DiscordClubMetadata for 'Patina Network'
+    UPDATE \"DiscordClubMetadata\" m
+    SET 
+      \"guildId\" = '1389762654452580373',
+      \"leaderboardChannelId\" = '1401739528057655436'
+    FROM \"DiscordClub\" c
+    WHERE c.\"id\" = m.\"discordClubId\"
+      AND c.\"name\" = 'Patina Network';
   "
 
 echo "Database copy completed successfully!"


### PR DESCRIPTION
… the sake of testability + fix some weird logic what would cause the script to fail (DO doesn't support transaction_timeout which would cause the script to fail)

## Notion Ticket (use public link, not private)

https://codebloom.notion.site/Update-prod-to-stg-copy-script-to-fix-DiscordClubMetadata-for-the-sake-of-testability-2b47c85563aa8075b19dd02d3713eb6a?source=copy_link

<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

### Staging

after script ran, stg has data that points to our local server instead:
<img width="706" height="249" alt="image" src="https://github.com/user-attachments/assets/0b479af2-c800-49c8-a764-4e7a2c5c414d" />
<img width="974" height="332" alt="image" src="https://github.com/user-attachments/assets/de63a623-2db1-4436-8ae7-bdec48fc348c" />
