### PR TITLE
Dedupe same enums

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -10,7 +10,7 @@
         "test": "pnpm run typecheck && pnpm run prettier && pnpm run lint && pnpm run build",
         "fix": "pnpm run eslint:fix && pnpm run stylelint:fix && pnpm run prettier:fix",
         "lint": "pnpm run eslint && pnpm run stylelint",
-        "generate": "openapi-typescript http://localhost:8080/v3/api-docs -o src/lib/api/types/autogen/schema.ts --properties-required-by-default --enum --make-paths-enum && prettier --write \"src/lib/api/types/autogen/schema.ts\"",
+        "generate": "openapi-typescript http://localhost:8080/v3/api-docs -o src/lib/api/types/autogen/schema.ts --properties-required-by-default --enum --make-paths-enum --dedupe-enums && prettier --write \"src/lib/api/types/autogen/schema.ts\"",
         "generate:dev": "nodemon --watch ../ --ext java --exec \"pnpm run generate\"",
         "eslint": "eslint .",
         "eslint:fix": "eslint . --fix",


### PR DESCRIPTION
## Notion Ticket (use public link, not private)

https://codebloom.notion.site/Dedupe-enums-2b67c85563aa80beb2aec0879364d990?source=copy_link

## Description of changes

Dedupe enums on the frontend so we don’t have to unnecessarily map between them, causing extra work and complexity

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
