### PR TITLE
483: UI Waiting Duel Page

### DIFF
--- a/js/src/components/ui/duel/WaitingDuelPage.tsx
+++ b/js/src/components/ui/duel/WaitingDuelPage.tsx
@@ -1,0 +1,178 @@
+import { Api } from "@/lib/api/types";
+import {
+  Button,
+  Card,
+  Group,
+  Stack,
+  Text,
+  Badge,
+  CopyButton,
+  Avatar,
+  Box,
+  Center,
+} from "@mantine/core";
+
+interface DuelPlayer {
+  id: string;
+  leetcodeUsername: string;
+  ready: boolean;
+}
+
+interface DuelWaitingScreenProps {
+  lobby: Api<"LobbyDto">;
+  players?: DuelPlayer[];
+  currentUserId: string;
+  isHost: boolean;
+  onLeave: () => void;
+  onStart: () => void;
+}
+
+export function WaitingDuelPage({
+  lobby,
+  players = [],
+  currentUserId,
+  isHost,
+  onLeave,
+  onStart,
+}: DuelWaitingScreenProps) {
+  const player1 = players[0] ?? null;
+  const player2 = players[1] ?? null;
+  const bothPlayersPresent = !!player1 && !!player2;
+
+  return (
+    <Box
+      style={{
+        minHeight: "85vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Stack maw={480} w="100%" gap="xl">
+        <Card
+          padding="1.5rem"
+          radius="lg"
+          style={{
+            backgroundColor: "#1a1c23",
+            borderColor: "#3f3f46",
+            borderWidth: "2px",
+          }}
+        >
+          <Center mb="lg">
+            <CopyButton value={lobby.joinCode}>
+              {({ copied, copy }) => (
+                <Button
+                  size="md"
+                  variant="filled"
+                  onClick={copy}
+                  styles={{
+                    root: {
+                      backgroundColor: "#1a3a52",
+                      border: "1px solid #2a4a62",
+                      borderRadius: "12px",
+                    },
+                  }}
+                >
+                  <Group>
+                    <Text fw={700} ff="monospace" c="white" size="lg">
+                      {lobby.joinCode}
+                    </Text>
+                    <Badge
+                      color={copied ? "teal" : "green"}
+                      variant="filled"
+                      size="md"
+                    >
+                      {copied ? "✓ Copied" : "Copy"}
+                    </Badge>
+                  </Group>
+                </Button>
+              )}
+            </CopyButton>
+          </Center>
+          <Stack gap="lg">
+            <PlayerCard player={player1} currentUserId={currentUserId} />
+            <Center>
+              <Text
+                c="dimmed"
+                fw={700}
+                size="3.5rem"
+                style={{ fontStyle: "italic" }}
+              >
+                VS
+              </Text>
+            </Center>
+            <PlayerCard player={player2} currentUserId={currentUserId} />
+            <Stack mt="md">
+              <Group justify="center">
+                <Button variant="light" color="red" size="md" onClick={onLeave}>
+                  Leave Party
+                </Button>
+                {isHost && (
+                  <Button
+                    size="md"
+                    color="green"
+                    onClick={onStart}
+                    disabled={!bothPlayersPresent}
+                  >
+                    Start Duel
+                  </Button>
+                )}
+              </Group>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Box>
+  );
+}
+
+function PlayerCard({
+  player,
+  currentUserId,
+}: {
+  player: DuelPlayer | null;
+  currentUserId: string;
+}) {
+  const isCurrentUser = player?.id === currentUserId;
+  const displayName =
+    player ?
+      isCurrentUser ? `${player.leetcodeUsername} (You)`
+      : player.leetcodeUsername
+    : "Waiting for opponent...";
+
+  return (
+    <Card
+      radius="md"
+      style={{
+        backgroundColor: "#24262e",
+        borderColor: "#3f3f46",
+        borderWidth: "2px",
+      }}
+    >
+      <Stack align="center" gap={6}>
+        <Avatar
+          radius="xl"
+          size={48}
+          color={player ? "gray" : "dark"}
+          styles={{
+            root: {
+              border: "2px solid #3f3f46",
+              backgroundColor: player ? "#374151" : "#1f2937",
+            },
+          }}
+        >
+          <Text size="lg" fw={700} c={player ? "white" : "dimmed"}>
+            {player ? player.leetcodeUsername.charAt(0).toUpperCase() : "?"}
+          </Text>
+        </Avatar>
+        <Text
+          fw={600}
+          c={player ? "white" : "dimmed"}
+          style={!player ? { fontStyle: "italic" } : undefined}
+        >
+          {displayName}
+        </Text>
+      </Stack>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Notion Ticket (use public link, not private)
## [483](https://codebloom.notion.site/Define-the-initial-UI-when-waiting-for-a-duel-to-begin-2b67c85563aa80298babdc983aa8dcef)
https://www.notion.so/0pengu/Define-the-initial-UI-when-waiting-for-a-duel-to-begin-2b67c85563aa80298babdc983aa8dcef

## Description of changes

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<img width="1512" height="790" alt="Screenshot 2026-01-07 at 1 30 16 AM" src="https://github.com/user-attachments/assets/f94dd730-cb13-4cb6-a335-4019c8a75ca2" />

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
N/A: the waiting duel page relies on a lobby code so testing in staging wouldn't really make sense