### PR TITLE
515: Use git-crypt from an action which caches git-crypt (+ avoids ap…

### DIFF
--- a/.github/composite/load-secrets/action.yml
+++ b/.github/composite/load-secrets/action.yml
@@ -31,10 +31,7 @@ runs:
         passphrase: ${{ inputs.GPG_PASSPHRASE }}
 
     - name: Install git-crypt
-      shell: bash
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y git-crypt
+      uses: flydiverny/setup-git-crypt@v4
 
     - name: Verify git-crypt version
       shell: bash


### PR DESCRIPTION
…t), significantly speeding up load-secrets step

## Notion Ticket (use public link, not private)

https://codebloom.notion.site/Speed-up-load-secrets-2c47c85563aa8019adecde9a3270c93a?source=copy_link

## Description of changes

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

Before:

<img width="1506" height="57" alt="image" src="https://github.com/user-attachments/assets/8ca010e6-7250-42b7-9f5e-026509c9f121" />

After:

<img width="1498" height="49" alt="image" src="https://github.com/user-attachments/assets/94a844ae-0879-480c-adcb-b24786eee1c0" />


### Dev

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
