### PR TITLE
516: Update PR template in anticipation for new Notion CI changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,9 @@
-## Notion Ticket (use public link, not private)
-
+<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
 <!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->
 
 ## Description of changes
+
+## Checklist before review
 
 - [ ] I have done a thorough self-review of the PR
 - [ ] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.


### PR DESCRIPTION
## Notion Ticket (use public link, not private)

https://codebloom.notion.site/Add-notion-id-enforcement-to-PRs-commits-2c47c85563aa8004b79de6a3d04efff9

## Description of changes

Update PR template in anticipation of new Notion changes that will autosync the public Notion ticket URL to the PR.

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
