### PR TITLE
542: Update create duel to return party code in payload

### DIFF
--- a/src/main/java/com/patina/codebloom/api/duel/DuelController.java
+++ b/src/main/java/com/patina/codebloom/api/duel/DuelController.java
@@ -1,6 +1,7 @@
 package com.patina.codebloom.api.duel;
 
 import com.patina.codebloom.api.duel.body.JoinLobbyBody;
+import com.patina.codebloom.api.duel.body.PartyCreatedBody;
 import com.patina.codebloom.common.components.duel.DuelException;
 import com.patina.codebloom.common.components.duel.DuelManager;
 import com.patina.codebloom.common.db.models.lobby.Lobby;
@@ -289,7 +290,8 @@ public class DuelController {
     @ApiResponse(responseCode = "400", description = "Player is already in a lobby")
     @ApiResponse(responseCode = "401", description = "User not authenticated")
     @PostMapping("/party/create")
-    public ResponseEntity<ApiResponder<Empty>> createParty(@Protected final AuthenticationObject authenticationObject) {
+    public ResponseEntity<ApiResponder<PartyCreatedBody>> createParty(
+            @Protected final AuthenticationObject authenticationObject) {
         if (env.isProd()) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Endpoint is currently non-functional");
         }
@@ -327,7 +329,8 @@ public class DuelController {
         lobbyPlayerRepository.createLobbyPlayer(lobbyPlayer);
 
         return ResponseEntity.ok(ApiResponder.success(
-                "Lobby created successfully! Share the join code: " + lobby.getJoinCode(), Empty.of()));
+                "Lobby created successfully!",
+                PartyCreatedBody.builder().code(joinCode).build()));
     }
 
     @Operation(summary = "SSE endpoint for duel data", description = """

--- a/src/main/java/com/patina/codebloom/api/duel/body/PartyCreatedBody.java
+++ b/src/main/java/com/patina/codebloom/api/duel/body/PartyCreatedBody.java
@@ -1,0 +1,16 @@
+package com.patina.codebloom.api.duel.body;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@Jacksonized
+@ToString
+@EqualsAndHashCode
+public class PartyCreatedBody {
+    private final String code;
+}

--- a/src/test/java/com/patina/codebloom/api/duel/DuelControllerTest.java
+++ b/src/test/java/com/patina/codebloom/api/duel/DuelControllerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.javafaker.Faker;
 import com.patina.codebloom.api.duel.body.JoinLobbyBody;
+import com.patina.codebloom.api.duel.body.PartyCreatedBody;
 import com.patina.codebloom.common.components.duel.DuelException;
 import com.patina.codebloom.common.components.duel.DuelManager;
 import com.patina.codebloom.common.db.models.lobby.Lobby;
@@ -348,11 +349,11 @@ public class DuelControllerTest {
 
         when(lobbyPlayerRepository.findLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
 
-        ResponseEntity<ApiResponder<Empty>> response = duelController.createParty(authObj);
+        ResponseEntity<ApiResponder<PartyCreatedBody>> response = duelController.createParty(authObj);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         assertTrue(response.getBody().isSuccess());
-        assertTrue(response.getBody().getPayload() instanceof Empty);
+        assertTrue(response.getBody().getPayload().getCode() != null);
 
         ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
         ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
@@ -414,13 +415,18 @@ public class DuelControllerTest {
         when(lobbyPlayerRepository.findLobbyPlayerByPlayerId(user1.getId())).thenReturn(Optional.empty());
         when(lobbyPlayerRepository.findLobbyPlayerByPlayerId(user2.getId())).thenReturn(Optional.empty());
 
-        ResponseEntity<ApiResponder<Empty>> response1 = duelController.createParty(authObj1);
-        ResponseEntity<ApiResponder<Empty>> response2 = duelController.createParty(authObj2);
+        ResponseEntity<ApiResponder<PartyCreatedBody>> response1 = duelController.createParty(authObj1);
+        ResponseEntity<ApiResponder<PartyCreatedBody>> response2 = duelController.createParty(authObj2);
 
         assertEquals(200, response1.getStatusCode().value());
         assertEquals(200, response2.getStatusCode().value());
         assertTrue(response1.getBody().isSuccess());
         assertTrue(response2.getBody().isSuccess());
+        assertTrue(response1.getBody().getPayload().getCode() != null);
+        assertTrue(response2.getBody().getPayload().getCode() != null);
+        assertNotEquals(
+                response1.getBody().getPayload().getCode(),
+                response2.getBody().getPayload().getCode());
 
         ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
         ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
@@ -513,9 +519,10 @@ public class DuelControllerTest {
 
         when(lobbyPlayerRepository.findLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
 
-        ResponseEntity<ApiResponder<Empty>> response = duelController.createParty(authObj);
+        ResponseEntity<ApiResponder<PartyCreatedBody>> response = duelController.createParty(authObj);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
+        assertTrue(response.getBody().getPayload().getCode() != null);
 
         ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
         verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(playerCaptor.capture());
@@ -533,7 +540,8 @@ public class DuelControllerTest {
 
         when(lobbyPlayerRepository.findLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
 
-        ResponseEntity<ApiResponder<Empty>> response = duelController.createParty(authObj);
+        ResponseEntity<ApiResponder<PartyCreatedBody>> response = duelController.createParty(authObj);
+        assertTrue(response.getBody().getPayload().getCode() != null);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
 
@@ -553,14 +561,14 @@ public class DuelControllerTest {
 
         when(lobbyPlayerRepository.findLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
 
-        ResponseEntity<ApiResponder<Empty>> response = duelController.createParty(authObj);
+        ResponseEntity<ApiResponder<PartyCreatedBody>> response = duelController.createParty(authObj);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         assertTrue(response.getBody().isSuccess());
         assertTrue(
                 response.getBody().getMessage().contains("Lobby created successfully"),
                 "Message should indicate successful lobby creation");
-        assertTrue(response.getBody().getMessage().contains("join code"), "Message should mention join code");
+        assertTrue(response.getBody().getPayload().getCode() != null);
     }
 
     @Test


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [542](https://codebloom.notion.site/Update-create-duel-to-return-party-code-in-payload-2d67c85563aa80629bb8ec5c5110f567)

## Description of changes

Request to create party, if successful, returns a body with the party code.

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/5124f2b3-251f-4c54-905e-a8be80620dd0" />

### Staging

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/1943ff60-2629-4a74-9cdd-06aab07c0d07" />