### PR TITLE
536: Refactor party logic out of duel controller into PartyManager

### DIFF
--- a/src/main/java/com/patina/codebloom/common/components/duel/PartyManager.java
+++ b/src/main/java/com/patina/codebloom/common/components/duel/PartyManager.java
@@ -1,0 +1,153 @@
+package com.patina.codebloom.common.components.duel;
+
+import com.patina.codebloom.common.db.models.lobby.Lobby;
+import com.patina.codebloom.common.db.models.lobby.LobbyStatus;
+import com.patina.codebloom.common.db.models.lobby.player.LobbyPlayer;
+import com.patina.codebloom.common.db.repos.lobby.LobbyRepository;
+import com.patina.codebloom.common.db.repos.lobby.player.LobbyPlayerRepository;
+import com.patina.codebloom.common.time.StandardizedOffsetDateTime;
+import com.patina.codebloom.common.utils.duel.PartyCodeGenerator;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+/**
+ * The main difference between this class and {@code DuelManager} is that this class mainly handles operations with the
+ * idea of a "party", such as joining or leaving a party.
+ */
+@Component
+public class PartyManager {
+    private static final int MAX_PLAYER_COUNT = 2;
+
+    private final LobbyRepository lobbyRepository;
+    private final LobbyPlayerRepository lobbyPlayerRepository;
+
+    public PartyManager(LobbyPlayerRepository lobbyPlayerRepository, LobbyRepository lobbyRepository) {
+        this.lobbyRepository = lobbyRepository;
+        this.lobbyPlayerRepository = lobbyPlayerRepository;
+    }
+
+    public void joinParty(String userId, String partyCode) throws DuelException {
+        try {
+            var lobby = lobbyRepository
+                    .findAvailableLobbyByJoinCode(partyCode)
+                    .orElseThrow(() ->
+                            new DuelException(HttpStatus.NOT_FOUND, "The party with the given code cannot be found."));
+
+            var now = StandardizedOffsetDateTime.now();
+            if (lobby.getExpiresAt().isBefore(now)) {
+                // TODO: Could possibly invalidate this party here if it hasn't been invalidated
+                // yet.
+                throw new DuelException(HttpStatus.GONE, "The lobby has expired and cannot be joined.");
+            }
+
+            if (lobby.getPlayerCount() == MAX_PLAYER_COUNT) {
+                throw new DuelException(HttpStatus.CONFLICT, "This lobby already has the maximum number of players");
+            }
+
+            var availableLobby = lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(userId);
+
+            if (availableLobby.isPresent()) {
+                throw new DuelException(
+                        HttpStatus.CONFLICT, "You are already in a party. Please leave the party, then try again.");
+            }
+
+            var activeLobby = lobbyRepository.findActiveLobbyByLobbyPlayerPlayerId(userId);
+
+            if (activeLobby.isPresent()) {
+                throw new DuelException(
+                        HttpStatus.CONFLICT, "You are currently in a duel. Please forfeit the duel, then try again.");
+            }
+
+            lobbyPlayerRepository.createLobbyPlayer(LobbyPlayer.builder()
+                    .lobbyId(lobby.getId())
+                    .playerId(userId)
+                    .build());
+
+            lobby.setPlayerCount(lobby.getPlayerCount() + 1);
+            boolean isSuccessful = lobbyRepository.updateLobby(lobby);
+
+            if (!isSuccessful) {
+                throw new DuelException(
+                        HttpStatus.INTERNAL_SERVER_ERROR, "Failed to join party. Please try again later.");
+            }
+        } catch (DuelException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DuelException(e);
+        }
+    }
+
+    public void leaveParty(String userId) throws DuelException {
+        try {
+            LobbyPlayer existingLobbyPlayer = lobbyPlayerRepository
+                    .findValidLobbyPlayerByPlayerId(userId)
+                    .orElseThrow(() -> new DuelException(HttpStatus.NOT_FOUND, "You are not currently in a lobby."));
+
+            String lobbyId = existingLobbyPlayer.getLobbyId();
+
+            boolean isLobbyPlayerDeleted = lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId());
+            if (!isLobbyPlayerDeleted) {
+                throw new DuelException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to leave lobby. Please try again.");
+            }
+
+            Lobby lobby = lobbyRepository
+                    .findLobbyById(lobbyId)
+                    .orElseThrow(() -> new DuelException(HttpStatus.INTERNAL_SERVER_ERROR, "Something went wrong."));
+
+            int updatedPlayerCount = lobby.getPlayerCount() - 1;
+
+            lobby.setPlayerCount(updatedPlayerCount);
+            if (updatedPlayerCount == 0) {
+                lobby.setStatus(LobbyStatus.CLOSED);
+            } else {
+                lobby.setStatus(LobbyStatus.AVAILABLE);
+            }
+            lobbyRepository.updateLobby(lobby);
+        } catch (DuelException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DuelException(e);
+        }
+    }
+
+    public String createParty(String userId) throws DuelException {
+        try {
+            var existingLobbyPlayer = lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(userId);
+
+            if (existingLobbyPlayer.isPresent()) {
+                throw new DuelException(
+                        HttpStatus.CONFLICT,
+                        "You are already in a lobby. Please leave your current lobby before creating a new one.");
+            }
+
+            String joinCode = PartyCodeGenerator.generateCode();
+            OffsetDateTime expiresAt = StandardizedOffsetDateTime.now().plusMinutes(30);
+
+            Lobby lobby = Lobby.builder()
+                    .joinCode(joinCode)
+                    .status(LobbyStatus.AVAILABLE)
+                    .expiresAt(expiresAt)
+                    .playerCount(1)
+                    .winnerId(Optional.empty())
+                    .build();
+
+            lobbyRepository.createLobby(lobby);
+
+            LobbyPlayer lobbyPlayer = LobbyPlayer.builder()
+                    .lobbyId(lobby.getId())
+                    .playerId(userId)
+                    .points(0)
+                    .build();
+
+            lobbyPlayerRepository.createLobbyPlayer(lobbyPlayer);
+
+            return joinCode;
+        } catch (DuelException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DuelException(e);
+        }
+    }
+}

--- a/src/test/java/com/patina/codebloom/api/duel/DuelControllerTest.java
+++ b/src/test/java/com/patina/codebloom/api/duel/DuelControllerTest.java
@@ -1,14 +1,11 @@
 package com.patina.codebloom.api.duel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -19,20 +16,14 @@ import static org.mockito.Mockito.when;
 
 import com.github.javafaker.Faker;
 import com.patina.codebloom.api.duel.body.JoinLobbyBody;
-import com.patina.codebloom.api.duel.body.PartyCreatedBody;
 import com.patina.codebloom.common.components.duel.DuelException;
 import com.patina.codebloom.common.components.duel.DuelManager;
+import com.patina.codebloom.common.components.duel.PartyManager;
 import com.patina.codebloom.common.db.models.lobby.Lobby;
 import com.patina.codebloom.common.db.models.lobby.LobbyStatus;
-import com.patina.codebloom.common.db.models.lobby.player.LobbyPlayer;
 import com.patina.codebloom.common.db.models.user.User;
-import com.patina.codebloom.common.db.repos.lobby.LobbyQuestionRepository;
 import com.patina.codebloom.common.db.repos.lobby.LobbyRepository;
-import com.patina.codebloom.common.db.repos.lobby.player.LobbyPlayerRepository;
-import com.patina.codebloom.common.db.repos.lobby.player.question.LobbyPlayerQuestionRepository;
-import com.patina.codebloom.common.db.repos.question.questionbank.QuestionBankRepository;
 import com.patina.codebloom.common.dto.ApiResponder;
-import com.patina.codebloom.common.dto.Empty;
 import com.patina.codebloom.common.dto.lobby.DuelData;
 import com.patina.codebloom.common.env.Env;
 import com.patina.codebloom.common.security.AuthenticationObject;
@@ -47,9 +38,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
 
 public class DuelControllerTest {
@@ -58,24 +47,13 @@ public class DuelControllerTest {
     private final Faker faker;
 
     private DuelManager duelManager = mock(DuelManager.class);
+    private PartyManager partyManager = mock(PartyManager.class);
     private LobbyRepository lobbyRepository = mock(LobbyRepository.class);
-    private LobbyPlayerRepository lobbyPlayerRepository = mock(LobbyPlayerRepository.class);
     private Env env = mock(Env.class);
     private LobbyNotifyHandler lobbyNotifyHandler = mock(LobbyNotifyHandler.class);
-    private QuestionBankRepository questionBankRepository = mock(QuestionBankRepository.class);
-    private LobbyPlayerQuestionRepository lobbyPlayerQuestionRepository = mock(LobbyPlayerQuestionRepository.class);
-    private LobbyQuestionRepository lobbyQuestionRepository = mock(LobbyQuestionRepository.class);
 
     public DuelControllerTest() {
-        this.duelController = new DuelController(
-                env,
-                duelManager,
-                lobbyRepository,
-                lobbyPlayerRepository,
-                lobbyNotifyHandler,
-                questionBankRepository,
-                lobbyPlayerQuestionRepository,
-                lobbyQuestionRepository);
+        this.duelController = new DuelController(env, duelManager, partyManager, lobbyRepository, lobbyNotifyHandler);
         this.faker = Faker.instance();
     }
 
@@ -99,501 +77,6 @@ public class DuelControllerTest {
     }
 
     @Test
-    void testLeavePartySuccessWhenUserInPartyAndLobbyHasMultiplePlayers() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        String lobbyId = randomUUID();
-        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
-                .id(randomUUID())
-                .lobbyId(lobbyId)
-                .playerId(user.getId())
-                .points(50)
-                .build();
-
-        Lobby lobby = Lobby.builder()
-                .id(lobbyId)
-                .joinCode(PartyCodeGenerator.generateCode())
-                .status(LobbyStatus.AVAILABLE)
-                .expiresAt(OffsetDateTime.now().plusMinutes(30))
-                .playerCount(3)
-                .build();
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
-                .thenReturn(Optional.of(existingLobbyPlayer));
-        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
-                .thenReturn(true);
-        when(lobbyRepository.findLobbyById(lobbyId)).thenReturn(Optional.of(lobby));
-
-        ResponseEntity<ApiResponder<Empty>> response = duelController.leaveParty(authObj);
-
-        assertEquals(200, response.getStatusCode().value());
-        assertTrue(response.getBody().isSuccess());
-        assertEquals("Successfully left the lobby.", response.getBody().getMessage());
-
-        verify(lobbyPlayerRepository, times(1)).deleteLobbyPlayerById(existingLobbyPlayer.getId());
-        verify(lobbyRepository, times(0)).deleteLobbyById(any());
-
-        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
-        verify(lobbyRepository, times(1)).updateLobby(lobbyCaptor.capture());
-
-        Lobby updatedLobby = lobbyCaptor.getValue();
-        assertEquals(2, updatedLobby.getPlayerCount());
-        assertEquals(LobbyStatus.AVAILABLE, updatedLobby.getStatus());
-    }
-
-    @Test
-    void testLeavePartySuccessWhenLobbyDoesNotExist() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        String lobbyId = randomUUID();
-        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
-                .id(randomUUID())
-                .lobbyId(lobbyId)
-                .playerId(user.getId())
-                .points(50)
-                .build();
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
-                .thenReturn(Optional.of(existingLobbyPlayer));
-        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
-                .thenReturn(true);
-        when(lobbyRepository.findLobbyById(lobbyId)).thenReturn(Optional.empty());
-
-        ResponseStatusException exception =
-                assertThrows(ResponseStatusException.class, () -> duelController.leaveParty(authObj));
-
-        assertEquals(
-                HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                exception.getStatusCode().value());
-        assertEquals("Something went wrong.", exception.getReason());
-
-        verify(lobbyPlayerRepository, times(1)).deleteLobbyPlayerById(existingLobbyPlayer.getId());
-        verify(lobbyRepository, times(0)).updateLobby(any());
-        verify(lobbyRepository, times(0)).deleteLobbyById(any());
-    }
-
-    @Test
-    void testLeavePartyDecreasesPlayerCountCorrectly() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        String lobbyId = randomUUID();
-        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
-                .id(randomUUID())
-                .lobbyId(lobbyId)
-                .playerId(user.getId())
-                .points(0)
-                .build();
-
-        Lobby lobby = Lobby.builder()
-                .id(lobbyId)
-                .joinCode(PartyCodeGenerator.generateCode())
-                .status(LobbyStatus.AVAILABLE)
-                .expiresAt(OffsetDateTime.now().plusMinutes(30))
-                .playerCount(3)
-                .build();
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
-                .thenReturn(Optional.of(existingLobbyPlayer));
-        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
-                .thenReturn(true);
-        when(lobbyRepository.findLobbyById(lobbyId)).thenReturn(Optional.of(lobby));
-
-        ResponseEntity<ApiResponder<Empty>> response = duelController.leaveParty(authObj);
-
-        assertEquals(200, response.getStatusCode().value());
-        assertTrue(response.getBody().isSuccess());
-
-        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
-        verify(lobbyRepository, times(1)).updateLobby(lobbyCaptor.capture());
-
-        Lobby updatedLobby = lobbyCaptor.getValue();
-        assertEquals(2, updatedLobby.getPlayerCount());
-        assertEquals(LobbyStatus.AVAILABLE, updatedLobby.getStatus());
-
-        verify(lobbyRepository, times(0)).deleteLobbyById(any());
-    }
-
-    @Test
-    void testLeavePartyFailureWhenUserNotInLobby() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
-
-        ResponseStatusException exception =
-                assertThrows(ResponseStatusException.class, () -> duelController.leaveParty(authObj));
-
-        assertEquals(HttpStatus.NOT_FOUND.value(), exception.getStatusCode().value());
-        assertEquals("You are not currently in a lobby.", exception.getReason());
-
-        verify(lobbyPlayerRepository, times(0)).deleteLobbyPlayerById(any());
-        verify(lobbyRepository, times(0)).updateLobby(any());
-        verify(lobbyRepository, times(0)).deleteLobbyById(any());
-    }
-
-    @Test
-    void testLeavePartyFailureWhenDeletionFails() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        String lobbyId = randomUUID();
-        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
-                .id(randomUUID())
-                .lobbyId(lobbyId)
-                .playerId(user.getId())
-                .points(50)
-                .build();
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
-                .thenReturn(Optional.of(existingLobbyPlayer));
-        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
-                .thenReturn(false);
-
-        ResponseEntity<ApiResponder<Empty>> response = duelController.leaveParty(authObj);
-
-        assertEquals(500, response.getStatusCode().value());
-        assertFalse(response.getBody().isSuccess());
-        assertEquals(
-                "Failed to leave the lobby. Please try again.",
-                response.getBody().getMessage());
-
-        verify(lobbyPlayerRepository, times(1)).deleteLobbyPlayerById(existingLobbyPlayer.getId());
-        verify(lobbyRepository, times(0)).findLobbyById(any());
-        verify(lobbyRepository, times(0)).updateLobby(any());
-        verify(lobbyRepository, times(0)).deleteLobbyById(any());
-    }
-
-    @Test
-    void testLeavePartyFailureInProductionEnvironment() {
-        when(env.isProd()).thenReturn(true);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        org.springframework.web.server.ResponseStatusException exception = assertThrows(
-                org.springframework.web.server.ResponseStatusException.class, () -> duelController.leaveParty(authObj));
-
-        assertEquals(403, exception.getStatusCode().value());
-        assertEquals("Endpoint is currently non-functional", exception.getReason());
-
-        verify(lobbyPlayerRepository, times(0)).findValidLobbyPlayerByPlayerId(any());
-        verify(lobbyPlayerRepository, times(0)).deleteLobbyPlayerById(any());
-        verify(lobbyRepository, times(0)).findLobbyById(any());
-        verify(lobbyRepository, times(0)).updateLobby(any());
-        verify(lobbyRepository, times(0)).deleteLobbyById(any());
-    }
-
-    @Test
-    void testLeavePartySetsLobbyToClosedWhenLastPlayerLeaves() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        String lobbyId = randomUUID();
-        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
-                .id(randomUUID())
-                .lobbyId(lobbyId)
-                .playerId(user.getId())
-                .points(0)
-                .build();
-
-        Lobby lobby = Lobby.builder()
-                .id(lobbyId)
-                .joinCode(PartyCodeGenerator.generateCode())
-                .status(LobbyStatus.AVAILABLE)
-                .expiresAt(OffsetDateTime.now().plusMinutes(30))
-                .playerCount(1)
-                .build();
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
-                .thenReturn(Optional.of(existingLobbyPlayer));
-        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
-                .thenReturn(true);
-        when(lobbyRepository.findLobbyById(lobbyId)).thenReturn(Optional.of(lobby));
-
-        ResponseEntity<ApiResponder<Empty>> response = duelController.leaveParty(authObj);
-
-        assertEquals(200, response.getStatusCode().value());
-        assertTrue(response.getBody().isSuccess());
-
-        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
-        verify(lobbyRepository, times(1)).updateLobby(lobbyCaptor.capture());
-
-        Lobby updatedLobby = lobbyCaptor.getValue();
-        assertEquals(0, updatedLobby.getPlayerCount());
-        assertEquals(LobbyStatus.CLOSED, updatedLobby.getStatus());
-
-        verify(lobbyRepository, times(0)).deleteLobbyById(any());
-    }
-
-    @Test
-    void testCreatePartySuccessWhenUserNotInParty() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
-
-        ResponseEntity<ApiResponder<PartyCreatedBody>> response = duelController.createParty(authObj);
-
-        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
-        assertTrue(response.getBody().isSuccess());
-        assertTrue(response.getBody().getPayload().getCode() != null);
-
-        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
-        ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
-
-        verify(lobbyRepository, times(1)).createLobby(lobbyCaptor.capture());
-        verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(playerCaptor.capture());
-
-        Lobby createdLobby = lobbyCaptor.getValue();
-        assertNotNull(createdLobby.getJoinCode());
-        assertEquals(6, createdLobby.getJoinCode().length());
-        assertEquals(LobbyStatus.AVAILABLE, createdLobby.getStatus());
-        assertEquals(1, createdLobby.getPlayerCount());
-        assertTrue(createdLobby.getWinnerId().isEmpty());
-        assertNotNull(createdLobby.getExpiresAt());
-
-        LobbyPlayer createdPlayer = playerCaptor.getValue();
-        assertEquals(user.getId(), createdPlayer.getPlayerId());
-        assertEquals(0, createdPlayer.getPoints());
-    }
-
-    @Test
-    void testCreatePartyFailureWhenUserAlreadyInParty() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
-                .id(randomUUID())
-                .lobbyId(randomUUID())
-                .playerId(user.getId())
-                .points(100)
-                .build();
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
-                .thenReturn(Optional.of(existingLobbyPlayer));
-
-        ResponseStatusException exception =
-                assertThrows(ResponseStatusException.class, () -> duelController.createParty(authObj));
-
-        assertEquals(HttpStatus.CONFLICT.value(), exception.getStatusCode().value());
-        assertEquals(
-                "You are already in a lobby. Please leave your current lobby before creating a new one.",
-                exception.getReason());
-
-        verify(lobbyRepository, times(0)).createLobby(any());
-        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
-    }
-
-    @Test
-    void testMultipleUsersCanCreatePartiesIndependently() {
-        when(env.isProd()).thenReturn(false);
-
-        User user1 = createRandomUser();
-        User user2 = createRandomUser();
-        AuthenticationObject authObj1 = createAuthenticationObject(user1);
-        AuthenticationObject authObj2 = createAuthenticationObject(user2);
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user1.getId()))
-                .thenReturn(Optional.empty());
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user2.getId()))
-                .thenReturn(Optional.empty());
-
-        ResponseEntity<ApiResponder<PartyCreatedBody>> response1 = duelController.createParty(authObj1);
-        ResponseEntity<ApiResponder<PartyCreatedBody>> response2 = duelController.createParty(authObj2);
-
-        assertEquals(200, response1.getStatusCode().value());
-        assertEquals(200, response2.getStatusCode().value());
-        assertTrue(response1.getBody().isSuccess());
-        assertTrue(response2.getBody().isSuccess());
-        assertTrue(response1.getBody().getPayload().getCode() != null);
-        assertTrue(response2.getBody().getPayload().getCode() != null);
-        assertNotEquals(
-                response1.getBody().getPayload().getCode(),
-                response2.getBody().getPayload().getCode());
-
-        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
-        ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
-
-        verify(lobbyRepository, times(2)).createLobby(lobbyCaptor.capture());
-        verify(lobbyPlayerRepository, times(2)).createLobbyPlayer(playerCaptor.capture());
-
-        var lobbyPlayers = playerCaptor.getAllValues();
-        assertEquals(user1.getId(), lobbyPlayers.get(0).getPlayerId());
-        assertEquals(user2.getId(), lobbyPlayers.get(1).getPlayerId());
-    }
-
-    @Test
-    void testEachPartyHasUniqueJoinCode() {
-        when(env.isProd()).thenReturn(false);
-
-        User user1 = createRandomUser();
-        User user2 = createRandomUser();
-        AuthenticationObject authObj1 = createAuthenticationObject(user1);
-        AuthenticationObject authObj2 = createAuthenticationObject(user2);
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user1.getId()))
-                .thenReturn(Optional.empty());
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user2.getId()))
-                .thenReturn(Optional.empty());
-
-        duelController.createParty(authObj1);
-        duelController.createParty(authObj2);
-
-        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
-        verify(lobbyRepository, times(2)).createLobby(lobbyCaptor.capture());
-
-        var lobbies = lobbyCaptor.getAllValues();
-        assertNotEquals(lobbies.get(0).getJoinCode(), lobbies.get(1).getJoinCode());
-    }
-
-    @Test
-    void testPartyExpirationTimeIsSet30MinutesInFuture() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
-
-        OffsetDateTime beforeCreation = OffsetDateTime.now();
-
-        duelController.createParty(authObj);
-
-        OffsetDateTime afterCreation = OffsetDateTime.now();
-
-        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
-        verify(lobbyRepository, times(1)).createLobby(lobbyCaptor.capture());
-
-        Lobby createdLobby = lobbyCaptor.getValue();
-        OffsetDateTime expiresAt = createdLobby.getExpiresAt();
-
-        OffsetDateTime expectedExpiration = beforeCreation.plusMinutes(30);
-        assertTrue(
-                expiresAt.isAfter(expectedExpiration.minusSeconds(5)),
-                "Expiration time should be after expected 30 minute mark");
-        assertTrue(
-                expiresAt.isBefore(afterCreation.plusMinutes(30).plusSeconds(5)),
-                "Expiration time should be before expected 30 minute mark plus buffer");
-    }
-
-    @Test
-    void testCreatePartyFailsInProductionEnvironment() {
-        when(env.isProd()).thenReturn(true);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        org.springframework.web.server.ResponseStatusException exception = assertThrows(
-                org.springframework.web.server.ResponseStatusException.class,
-                () -> duelController.createParty(authObj));
-
-        assertEquals(HttpStatus.FORBIDDEN.value(), exception.getStatusCode().value());
-        assertEquals("Endpoint is currently non-functional", exception.getReason());
-
-        verify(lobbyPlayerRepository, times(0)).findValidLobbyPlayerByPlayerId(any());
-        verify(lobbyRepository, times(0)).createLobby(any());
-        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
-    }
-
-    @Test
-    void testNewLobbyPlayerStartsWithZeroPoints() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
-
-        ResponseEntity<ApiResponder<PartyCreatedBody>> response = duelController.createParty(authObj);
-
-        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
-        assertTrue(response.getBody().getPayload().getCode() != null);
-
-        ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
-        verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(playerCaptor.capture());
-
-        LobbyPlayer createdPlayer = playerCaptor.getValue();
-        assertEquals(0, createdPlayer.getPoints());
-    }
-
-    @Test
-    void testCreatePartyInitializesLobbyWithoutWinner() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
-
-        ResponseEntity<ApiResponder<PartyCreatedBody>> response = duelController.createParty(authObj);
-        assertTrue(response.getBody().getPayload().getCode() != null);
-
-        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
-
-        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
-        verify(lobbyRepository, times(1)).createLobby(lobbyCaptor.capture());
-
-        Lobby createdLobby = lobbyCaptor.getValue();
-        assertTrue(createdLobby.getWinnerId().isEmpty());
-    }
-
-    @Test
-    void testSuccessResponseContainsJoinCode() {
-        when(env.isProd()).thenReturn(false);
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
-
-        ResponseEntity<ApiResponder<PartyCreatedBody>> response = duelController.createParty(authObj);
-
-        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
-        assertTrue(response.getBody().isSuccess());
-        assertTrue(
-                response.getBody().getMessage().contains("Lobby created successfully"),
-                "Message should indicate successful lobby creation");
-        assertTrue(response.getBody().getPayload().getCode() != null);
-    }
-
-    @Test
-    @DisplayName("Join lobby - cannot find lobby by join code")
-    void joinPartyCannotFindLobbyByJoinCode() {
-        when(env.isProd()).thenReturn(false);
-
-        var joinPartyBody = JoinLobbyBody.builder().partyCode("ABC123").build();
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        when(lobbyRepository.findAvailableLobbyByJoinCode(argThat(joinPartyBody.getPartyCode()::equals)))
-                .thenReturn(Optional.empty());
-
-        assertThrows(ResponseStatusException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
-        });
-    }
-
-    @Test
     @DisplayName("Join lobby - invalid code length")
     void joinPartyIncorrectLengthCode() {
         when(env.isProd()).thenReturn(false);
@@ -604,7 +87,7 @@ public class DuelControllerTest {
         AuthenticationObject authObj = createAuthenticationObject(user);
 
         var ex = assertThrows(ValidationException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
+            duelController.joinParty(authObj, joinPartyBody);
         });
 
         assertEquals("Lobby code must be exactly 6 characters.", ex.getMessage());
@@ -621,7 +104,7 @@ public class DuelControllerTest {
         AuthenticationObject authObj = createAuthenticationObject(user);
 
         var ex = assertThrows(ValidationException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
+            duelController.joinParty(authObj, joinPartyBody);
         });
 
         assertEquals("Lobby code may not be null or empty.", ex.getMessage());
@@ -638,191 +121,10 @@ public class DuelControllerTest {
         AuthenticationObject authObj = createAuthenticationObject(user);
 
         var ex = assertThrows(ValidationException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
+            duelController.joinParty(authObj, joinPartyBody);
         });
 
         assertEquals("Lobby code may not be null or empty.", ex.getMessage());
-    }
-
-    @Test
-    @DisplayName("Join lobby - successful join")
-    void joinLobbySuccess() {
-        when(env.isProd()).thenReturn(false);
-
-        var joinPartyBody = JoinLobbyBody.builder().partyCode("ABC123").build();
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        Lobby mockLobby = Lobby.builder()
-                .id(randomUUID())
-                .joinCode("ABC123")
-                .expiresAt(StandardizedOffsetDateTime.now().plus(1, ChronoUnit.HOURS))
-                .status(LobbyStatus.AVAILABLE)
-                .playerCount(1)
-                .build();
-
-        when(lobbyRepository.findAvailableLobbyByJoinCode("ABC123")).thenReturn(Optional.of(mockLobby));
-        when(lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(user.getId()))
-                .thenReturn(Optional.empty());
-        when(lobbyRepository.findActiveLobbyByLobbyPlayerPlayerId(user.getId())).thenReturn(Optional.empty());
-        when(lobbyRepository.updateLobby(any(Lobby.class))).thenReturn(true);
-
-        ResponseEntity<ApiResponder<Empty>> response = duelController.joinLobby(authObj, joinPartyBody);
-
-        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
-        assertTrue(response.getBody().isSuccess());
-        assertEquals("Party successfully joined!", response.getBody().getMessage());
-
-        verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(any(LobbyPlayer.class));
-        verify(lobbyRepository, times(1)).updateLobby(argThat(lobby -> lobby.getPlayerCount() == 2));
-    }
-
-    @Test
-    @DisplayName("Join lobby - lobby at max capacity")
-    void joinLobbyMaxCapacity() {
-        when(env.isProd()).thenReturn(false);
-
-        var joinPartyBody = JoinLobbyBody.builder().partyCode("ABC123").build();
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        Lobby mockLobby = Lobby.builder()
-                .id(randomUUID())
-                .joinCode("ABC123")
-                .status(LobbyStatus.AVAILABLE)
-                .expiresAt(StandardizedOffsetDateTime.now().plus(1, ChronoUnit.HOURS))
-                .playerCount(2)
-                .build();
-
-        when(lobbyRepository.findAvailableLobbyByJoinCode("ABC123")).thenReturn(Optional.of(mockLobby));
-
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
-        });
-
-        assertEquals(HttpStatus.CONFLICT.value(), exception.getStatusCode().value());
-        assertEquals("This lobby already has the maximum number of players", exception.getReason());
-
-        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
-        verify(lobbyRepository, times(0)).updateLobby(any());
-    }
-
-    @Test
-    @DisplayName("Join lobby - player already in available lobby")
-    void joinLobbyPlayerInAvailableLobby() {
-        when(env.isProd()).thenReturn(false);
-
-        var joinPartyBody = JoinLobbyBody.builder().partyCode("ABC123").build();
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        Lobby mockLobby = Lobby.builder()
-                .id(randomUUID())
-                .joinCode("ABC123")
-                .expiresAt(StandardizedOffsetDateTime.now().plus(1, ChronoUnit.HOURS))
-                .status(LobbyStatus.AVAILABLE)
-                .playerCount(1)
-                .build();
-
-        Lobby existingLobby = Lobby.builder()
-                .id(randomUUID())
-                .expiresAt(StandardizedOffsetDateTime.now().plus(1, ChronoUnit.HOURS))
-                .status(LobbyStatus.AVAILABLE)
-                .build();
-
-        when(lobbyRepository.findAvailableLobbyByJoinCode("ABC123")).thenReturn(Optional.of(mockLobby));
-        when(lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(user.getId()))
-                .thenReturn(Optional.of(existingLobby));
-
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
-        });
-
-        assertEquals(HttpStatus.CONFLICT.value(), exception.getStatusCode().value());
-        assertEquals("You are already in a party. Please leave the party, then try again.", exception.getReason());
-
-        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
-        verify(lobbyRepository, times(0)).updateLobby(any());
-    }
-
-    @Test
-    @DisplayName("Join lobby - player already in active lobby")
-    void joinLobbyPlayerInActiveLobby() {
-        when(env.isProd()).thenReturn(false);
-
-        var joinPartyBody = JoinLobbyBody.builder().partyCode("ABC123").build();
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        Lobby mockLobby = Lobby.builder()
-                .id(randomUUID())
-                .joinCode("ABC123")
-                .status(LobbyStatus.AVAILABLE)
-                .expiresAt(StandardizedOffsetDateTime.now().plus(1, ChronoUnit.HOURS))
-                .playerCount(1)
-                .build();
-
-        Lobby activeLobby = Lobby.builder()
-                .id(randomUUID())
-                .status(LobbyStatus.ACTIVE)
-                .expiresAt(StandardizedOffsetDateTime.now().plus(1, ChronoUnit.HOURS))
-                .build();
-
-        when(lobbyRepository.findAvailableLobbyByJoinCode("ABC123")).thenReturn(Optional.of(mockLobby));
-        when(lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(user.getId()))
-                .thenReturn(Optional.empty());
-        when(lobbyRepository.findActiveLobbyByLobbyPlayerPlayerId(user.getId())).thenReturn(Optional.of(activeLobby));
-
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
-        });
-
-        assertEquals(HttpStatus.CONFLICT.value(), exception.getStatusCode().value());
-        assertEquals("You are currently in a duel. Please forfeit the duel, then try again.", exception.getReason());
-
-        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
-        verify(lobbyRepository, times(0)).updateLobby(any());
-    }
-
-    @Test
-    @DisplayName("Join lobby - lobby update failure")
-    void joinLobbyUpdateFailure() {
-        when(env.isProd()).thenReturn(false);
-
-        var joinPartyBody = JoinLobbyBody.builder().partyCode("ABC123").build();
-
-        User user = createRandomUser();
-        AuthenticationObject authObj = createAuthenticationObject(user);
-
-        Lobby mockLobby = Lobby.builder()
-                .id(randomUUID())
-                .joinCode("ABC123")
-                .status(LobbyStatus.AVAILABLE)
-                .expiresAt(StandardizedOffsetDateTime.now().plus(1, ChronoUnit.HOURS))
-                .playerCount(1)
-                .build();
-
-        when(lobbyRepository.findAvailableLobbyByJoinCode("ABC123")).thenReturn(Optional.of(mockLobby));
-        when(lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(user.getId()))
-                .thenReturn(Optional.empty());
-        when(lobbyRepository.findActiveLobbyByLobbyPlayerPlayerId(user.getId())).thenReturn(Optional.empty());
-        when(lobbyRepository.updateLobby(any(Lobby.class))).thenReturn(false);
-
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
-        });
-
-        assertEquals(
-                HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                exception.getStatusCode().value());
-        assertEquals("Failed to join party. Please try again later.", exception.getReason());
-
-        verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(any(LobbyPlayer.class));
-        verify(lobbyRepository, times(1)).updateLobby(any(Lobby.class));
     }
 
     @Test
@@ -836,20 +138,21 @@ public class DuelControllerTest {
         AuthenticationObject authObj = createAuthenticationObject(user);
 
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
+            duelController.joinParty(authObj, joinPartyBody);
         });
 
         assertEquals(HttpStatus.FORBIDDEN.value(), exception.getStatusCode().value());
         assertEquals("Endpoint is currently non-functional", exception.getReason());
 
-        verify(lobbyRepository, times(0)).findAvailableLobbyByJoinCode(any());
-        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
-        verify(lobbyRepository, times(0)).updateLobby(any());
+        try {
+            verify(partyManager, times(0)).joinParty(any(), any());
+        } catch (DuelException e) {
+            fail(e);
+        }
     }
 
     @Test
-    @DisplayName("Join lobby - lobby has expired")
-    void joinLobbyExpiredLobby() {
+    void testJoinPartyPartyManagerFailed() {
         when(env.isProd()).thenReturn(false);
 
         var joinPartyBody = JoinLobbyBody.builder().partyCode("ABC123").build();
@@ -857,26 +160,208 @@ public class DuelControllerTest {
         User user = createRandomUser();
         AuthenticationObject authObj = createAuthenticationObject(user);
 
-        OffsetDateTime pastTime = OffsetDateTime.now().minusMinutes(5);
-        Lobby expiredLobby = Lobby.builder()
-                .id(randomUUID())
-                .joinCode("ABC123")
-                .status(LobbyStatus.AVAILABLE)
-                .playerCount(1)
-                .expiresAt(pastTime)
-                .build();
+        try {
+            doThrow(new DuelException(HttpStatus.NOT_FOUND, "The party with the given code cannot be found."))
+                    .when(partyManager)
+                    .joinParty(eq(user.getId()), eq("ABC123"));
+        } catch (DuelException _) {
+        }
 
-        when(lobbyRepository.findAvailableLobbyByJoinCode("ABC123")).thenReturn(Optional.of(expiredLobby));
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> duelController.joinParty(authObj, joinPartyBody));
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            duelController.joinLobby(authObj, joinPartyBody);
-        });
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals("The party with the given code cannot be found.", exception.getReason());
 
-        assertEquals(HttpStatus.GONE.value(), exception.getStatusCode().value());
-        assertEquals("The lobby has expired and cannot be joined.", exception.getReason());
+        try {
+            verify(partyManager, times(1)).joinParty(eq(user.getId()), eq("ABC123"));
+        } catch (DuelException e) {
+            fail(e);
+        }
+    }
 
-        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
-        verify(lobbyRepository, times(0)).updateLobby(any());
+    @Test
+    void testJoinPartyHappyPath() {
+        when(env.isProd()).thenReturn(false);
+
+        var joinPartyBody = JoinLobbyBody.builder().partyCode("ABC123").build();
+
+        User user = createRandomUser();
+        AuthenticationObject authObj = createAuthenticationObject(user);
+
+        try {
+            doNothing().when(partyManager).joinParty(eq(user.getId()), eq("ABC123"));
+        } catch (DuelException _) {
+        }
+
+        var response = duelController.joinParty(authObj, joinPartyBody);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        var apiResponder = response.getBody();
+        assertTrue(apiResponder.isSuccess());
+        assertEquals("Party successfully joined!", apiResponder.getMessage());
+
+        try {
+            verify(partyManager, times(1)).joinParty(eq(user.getId()), eq("ABC123"));
+        } catch (DuelException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testLeavePartyFailureInProductionEnvironment() {
+        when(env.isProd()).thenReturn(true);
+
+        User user = createRandomUser();
+        AuthenticationObject authObj = createAuthenticationObject(user);
+
+        org.springframework.web.server.ResponseStatusException exception = assertThrows(
+                org.springframework.web.server.ResponseStatusException.class, () -> duelController.leaveParty(authObj));
+
+        assertEquals(403, exception.getStatusCode().value());
+        assertEquals("Endpoint is currently non-functional", exception.getReason());
+
+        try {
+            verify(partyManager, times(0)).leaveParty(any());
+        } catch (DuelException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testLeavePartyPartyManagerFailed() {
+        when(env.isProd()).thenReturn(false);
+
+        User user = createRandomUser();
+        AuthenticationObject authObj = createAuthenticationObject(user);
+
+        try {
+            doThrow(new DuelException(HttpStatus.NOT_FOUND, "You are not currently in a lobby."))
+                    .when(partyManager)
+                    .leaveParty(eq(user.getId()));
+        } catch (DuelException _) {
+        }
+
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> duelController.leaveParty(authObj));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals("You are not currently in a lobby.", exception.getReason());
+
+        try {
+            verify(partyManager, times(1)).leaveParty(eq(user.getId()));
+        } catch (DuelException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testLeavePartyHappyPath() {
+        when(env.isProd()).thenReturn(false);
+
+        User user = createRandomUser();
+        AuthenticationObject authObj = createAuthenticationObject(user);
+
+        try {
+            doNothing().when(partyManager).leaveParty(eq(user.getId()));
+        } catch (DuelException _) {
+        }
+
+        var response = duelController.leaveParty(authObj);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        var apiResponder = response.getBody();
+        assertTrue(apiResponder.isSuccess());
+        assertEquals("Successfully left the party.", apiResponder.getMessage());
+
+        try {
+            verify(partyManager, times(1)).leaveParty(eq(user.getId()));
+        } catch (DuelException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testCreatePartyFailsInProductionEnvironment() {
+        when(env.isProd()).thenReturn(true);
+
+        User user = createRandomUser();
+        AuthenticationObject authObj = createAuthenticationObject(user);
+
+        org.springframework.web.server.ResponseStatusException exception = assertThrows(
+                org.springframework.web.server.ResponseStatusException.class,
+                () -> duelController.createParty(authObj));
+
+        assertEquals(HttpStatus.FORBIDDEN.value(), exception.getStatusCode().value());
+        assertEquals("Endpoint is currently non-functional", exception.getReason());
+
+        try {
+            verify(partyManager, times(0)).createParty(any());
+        } catch (DuelException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testCreatePartyPartyManagerFailed() {
+        when(env.isProd()).thenReturn(false);
+
+        User user = createRandomUser();
+        AuthenticationObject authObj = createAuthenticationObject(user);
+
+        try {
+            doThrow(new DuelException(
+                            HttpStatus.CONFLICT,
+                            "You are already in a lobby. Please leave your current lobby before creating a new one."))
+                    .when(partyManager)
+                    .createParty(eq(user.getId()));
+        } catch (DuelException _) {
+        }
+
+        ResponseStatusException exception =
+                assertThrows(ResponseStatusException.class, () -> duelController.createParty(authObj));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+        assertEquals(
+                "You are already in a lobby. Please leave your current lobby before creating a new one.",
+                exception.getReason());
+
+        try {
+            verify(partyManager, times(1)).createParty(eq(user.getId()));
+        } catch (DuelException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void testCreatePartyHappyPath() {
+        when(env.isProd()).thenReturn(false);
+
+        User user = createRandomUser();
+        AuthenticationObject authObj = createAuthenticationObject(user);
+
+        try {
+            when(partyManager.createParty(eq(user.getId()))).thenReturn("ABC123");
+        } catch (DuelException _) {
+        }
+
+        var response = duelController.createParty(authObj);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        var apiResponder = response.getBody();
+        assertTrue(apiResponder.isSuccess());
+        assertEquals("Lobby created successfully!", apiResponder.getMessage());
+        assertNotNull(apiResponder.getPayload());
+        assertEquals("ABC123", apiResponder.getPayload().getCode());
+
+        try {
+            verify(partyManager, times(1)).createParty(eq(user.getId()));
+        } catch (DuelException e) {
+            fail(e);
+        }
     }
 
     @Test

--- a/src/test/java/com/patina/codebloom/component/duel/PartyManagerTest.java
+++ b/src/test/java/com/patina/codebloom/component/duel/PartyManagerTest.java
@@ -1,0 +1,601 @@
+package com.patina.codebloom.component.duel;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.github.javafaker.Faker;
+import com.patina.codebloom.common.components.duel.DuelException;
+import com.patina.codebloom.common.components.duel.PartyManager;
+import com.patina.codebloom.common.db.models.lobby.Lobby;
+import com.patina.codebloom.common.db.models.lobby.LobbyStatus;
+import com.patina.codebloom.common.db.models.lobby.player.LobbyPlayer;
+import com.patina.codebloom.common.db.models.user.User;
+import com.patina.codebloom.common.db.repos.lobby.LobbyRepository;
+import com.patina.codebloom.common.db.repos.lobby.player.LobbyPlayerRepository;
+import com.patina.codebloom.common.time.StandardizedOffsetDateTime;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+
+public class PartyManagerTest {
+    private final PartyManager partyManager;
+    private final Faker faker;
+
+    private final LobbyPlayerRepository lobbyPlayerRepository = mock(LobbyPlayerRepository.class);
+    private final LobbyRepository lobbyRepository = mock(LobbyRepository.class);
+
+    public PartyManagerTest() {
+        partyManager = new PartyManager(lobbyPlayerRepository, lobbyRepository);
+        this.faker = Faker.instance();
+    }
+
+    private String randomUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    private User createRandomUser() {
+        return User.builder()
+                .id(randomUUID())
+                .discordId(String.valueOf(faker.number().randomNumber(18, true)))
+                .discordName(faker.name().username())
+                .leetcodeUsername(faker.name().username())
+                .admin(false)
+                .verifyKey(faker.crypto().md5())
+                .build();
+    }
+
+    @Test
+    void testCreatePartySuccessWhenUserNotInParty() throws DuelException {
+        User user = createRandomUser();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
+
+        String joinCode = partyManager.createParty(user.getId());
+
+        assertNotNull(joinCode);
+        assertEquals(6, joinCode.length());
+
+        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
+        ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
+
+        verify(lobbyRepository, times(1)).createLobby(lobbyCaptor.capture());
+        verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(playerCaptor.capture());
+
+        Lobby createdLobby = lobbyCaptor.getValue();
+        assertNotNull(createdLobby.getJoinCode());
+        assertEquals(6, createdLobby.getJoinCode().length());
+        assertEquals(LobbyStatus.AVAILABLE, createdLobby.getStatus());
+        assertEquals(1, createdLobby.getPlayerCount());
+        assertTrue(createdLobby.getWinnerId().isEmpty());
+        assertNotNull(createdLobby.getExpiresAt());
+
+        LobbyPlayer createdPlayer = playerCaptor.getValue();
+        assertEquals(user.getId(), createdPlayer.getPlayerId());
+        assertEquals(0, createdPlayer.getPoints());
+    }
+
+    @Test
+    void testCreatePartyFailureWhenUserAlreadyInParty() {
+        User user = createRandomUser();
+
+        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
+                .id(randomUUID())
+                .lobbyId(randomUUID())
+                .playerId(user.getId())
+                .points(100)
+                .build();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
+                .thenReturn(Optional.of(existingLobbyPlayer));
+
+        DuelException exception = assertThrows(DuelException.class, () -> partyManager.createParty(user.getId()));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus().orElseThrow());
+        assertEquals(
+                "You are already in a lobby. Please leave your current lobby before creating a new one.",
+                exception.getMessage());
+
+        verify(lobbyRepository, times(0)).createLobby(any());
+        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
+    }
+
+    @Test
+    void testMultipleUsersCanCreatePartiesIndependently() throws DuelException {
+        User user1 = createRandomUser();
+        User user2 = createRandomUser();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user1.getId()))
+                .thenReturn(Optional.empty());
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user2.getId()))
+                .thenReturn(Optional.empty());
+
+        String joinCode1 = partyManager.createParty(user1.getId());
+        String joinCode2 = partyManager.createParty(user2.getId());
+
+        assertNotNull(joinCode1);
+        assertNotNull(joinCode2);
+        assertNotEquals(joinCode1, joinCode2);
+
+        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
+        ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
+
+        verify(lobbyRepository, times(2)).createLobby(lobbyCaptor.capture());
+        verify(lobbyPlayerRepository, times(2)).createLobbyPlayer(playerCaptor.capture());
+
+        var lobbyPlayers = playerCaptor.getAllValues();
+        assertEquals(user1.getId(), lobbyPlayers.get(0).getPlayerId());
+        assertEquals(user2.getId(), lobbyPlayers.get(1).getPlayerId());
+    }
+
+    @Test
+    void testEachPartyHasUniqueJoinCode() throws DuelException {
+        User user1 = createRandomUser();
+        User user2 = createRandomUser();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user1.getId()))
+                .thenReturn(Optional.empty());
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user2.getId()))
+                .thenReturn(Optional.empty());
+
+        partyManager.createParty(user1.getId());
+        partyManager.createParty(user2.getId());
+
+        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
+        verify(lobbyRepository, times(2)).createLobby(lobbyCaptor.capture());
+
+        var lobbies = lobbyCaptor.getAllValues();
+        assertNotEquals(lobbies.get(0).getJoinCode(), lobbies.get(1).getJoinCode());
+    }
+
+    @Test
+    void testPartyExpirationTimeIsSet30MinutesInFuture() throws DuelException {
+        User user = createRandomUser();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
+
+        OffsetDateTime beforeCreation = OffsetDateTime.now();
+
+        partyManager.createParty(user.getId());
+
+        OffsetDateTime afterCreation = OffsetDateTime.now();
+
+        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
+        verify(lobbyRepository, times(1)).createLobby(lobbyCaptor.capture());
+
+        Lobby createdLobby = lobbyCaptor.getValue();
+        OffsetDateTime expiresAt = createdLobby.getExpiresAt();
+
+        OffsetDateTime expectedExpiration = beforeCreation.plusMinutes(30);
+        assertTrue(
+                expiresAt.isAfter(expectedExpiration.minusSeconds(5)),
+                "Expiration time should be after expected 30 minute mark");
+        assertTrue(
+                expiresAt.isBefore(afterCreation.plusMinutes(30).plusSeconds(5)),
+                "Expiration time should be before expected 30 minute mark plus buffer");
+    }
+
+    @Test
+    void testNewLobbyPlayerStartsWithZeroPoints() throws DuelException {
+        User user = createRandomUser();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
+
+        String joinCode = partyManager.createParty(user.getId());
+
+        assertNotNull(joinCode);
+
+        ArgumentCaptor<LobbyPlayer> playerCaptor = ArgumentCaptor.forClass(LobbyPlayer.class);
+        verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(playerCaptor.capture());
+
+        LobbyPlayer createdPlayer = playerCaptor.getValue();
+        assertEquals(0, createdPlayer.getPoints());
+    }
+
+    @Test
+    void testCreatePartyInitializesLobbyWithoutWinner() throws DuelException {
+        User user = createRandomUser();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
+
+        String joinCode = partyManager.createParty(user.getId());
+        assertNotNull(joinCode);
+
+        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
+        verify(lobbyRepository, times(1)).createLobby(lobbyCaptor.capture());
+
+        Lobby createdLobby = lobbyCaptor.getValue();
+        assertTrue(createdLobby.getWinnerId().isEmpty());
+    }
+
+    @Test
+    void testCreatePartyReturnsJoinCode() throws DuelException {
+        User user = createRandomUser();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
+
+        String joinCode = partyManager.createParty(user.getId());
+
+        assertNotNull(joinCode);
+        assertEquals(6, joinCode.length());
+    }
+
+    @Test
+    void testJoinPartyCannotFindLobbyByJoinCode() {
+        User user = createRandomUser();
+        String partyCode = "ABC123";
+
+        when(lobbyRepository.findAvailableLobbyByJoinCode(eq(partyCode))).thenReturn(Optional.empty());
+
+        DuelException exception =
+                assertThrows(DuelException.class, () -> partyManager.joinParty(user.getId(), partyCode));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getHttpStatus().orElseThrow());
+        assertEquals("The party with the given code cannot be found.", exception.getMessage());
+    }
+
+    @Test
+    void testJoinPartySuccess() throws DuelException {
+        User user = createRandomUser();
+        String partyCode = "ABC123";
+
+        Lobby mockLobby = Lobby.builder()
+                .id(randomUUID())
+                .joinCode(partyCode)
+                .expiresAt(StandardizedOffsetDateTime.now().plusHours(1))
+                .status(LobbyStatus.AVAILABLE)
+                .playerCount(1)
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyRepository.findAvailableLobbyByJoinCode(partyCode)).thenReturn(Optional.of(mockLobby));
+        when(lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(user.getId()))
+                .thenReturn(Optional.empty());
+        when(lobbyRepository.findActiveLobbyByLobbyPlayerPlayerId(user.getId())).thenReturn(Optional.empty());
+        when(lobbyRepository.updateLobby(any(Lobby.class))).thenReturn(true);
+
+        partyManager.joinParty(user.getId(), partyCode);
+
+        verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(any(LobbyPlayer.class));
+        verify(lobbyRepository, times(1)).updateLobby(argThat(lobby -> lobby.getPlayerCount() == 2));
+    }
+
+    @Test
+    void testJoinPartyLobbyAtMaxCapacity() {
+        User user = createRandomUser();
+        String partyCode = "ABC123";
+
+        Lobby mockLobby = Lobby.builder()
+                .id(randomUUID())
+                .joinCode(partyCode)
+                .status(LobbyStatus.AVAILABLE)
+                .expiresAt(StandardizedOffsetDateTime.now().plusHours(1))
+                .playerCount(2)
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyRepository.findAvailableLobbyByJoinCode(partyCode)).thenReturn(Optional.of(mockLobby));
+
+        DuelException exception =
+                assertThrows(DuelException.class, () -> partyManager.joinParty(user.getId(), partyCode));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus().orElseThrow());
+        assertEquals("This lobby already has the maximum number of players", exception.getMessage());
+
+        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
+        verify(lobbyRepository, times(0)).updateLobby(any());
+    }
+
+    @Test
+    void testJoinPartyPlayerAlreadyInAvailableLobby() {
+        User user = createRandomUser();
+        String partyCode = "ABC123";
+
+        Lobby mockLobby = Lobby.builder()
+                .id(randomUUID())
+                .joinCode(partyCode)
+                .expiresAt(StandardizedOffsetDateTime.now().plusHours(1))
+                .status(LobbyStatus.AVAILABLE)
+                .playerCount(1)
+                .winnerId(Optional.empty())
+                .build();
+
+        Lobby existingLobby = Lobby.builder()
+                .id(randomUUID())
+                .expiresAt(StandardizedOffsetDateTime.now().plusHours(1))
+                .status(LobbyStatus.AVAILABLE)
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyRepository.findAvailableLobbyByJoinCode(partyCode)).thenReturn(Optional.of(mockLobby));
+        when(lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(user.getId()))
+                .thenReturn(Optional.of(existingLobby));
+
+        DuelException exception =
+                assertThrows(DuelException.class, () -> partyManager.joinParty(user.getId(), partyCode));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus().orElseThrow());
+        assertEquals("You are already in a party. Please leave the party, then try again.", exception.getMessage());
+
+        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
+        verify(lobbyRepository, times(0)).updateLobby(any());
+    }
+
+    @Test
+    void testJoinPartyPlayerAlreadyInActiveLobby() {
+        User user = createRandomUser();
+        String partyCode = "ABC123";
+
+        Lobby mockLobby = Lobby.builder()
+                .id(randomUUID())
+                .joinCode(partyCode)
+                .status(LobbyStatus.AVAILABLE)
+                .expiresAt(StandardizedOffsetDateTime.now().plusHours(1))
+                .playerCount(1)
+                .winnerId(Optional.empty())
+                .build();
+
+        Lobby activeLobby = Lobby.builder()
+                .id(randomUUID())
+                .status(LobbyStatus.ACTIVE)
+                .expiresAt(StandardizedOffsetDateTime.now().plusHours(1))
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyRepository.findAvailableLobbyByJoinCode(partyCode)).thenReturn(Optional.of(mockLobby));
+        when(lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(user.getId()))
+                .thenReturn(Optional.empty());
+        when(lobbyRepository.findActiveLobbyByLobbyPlayerPlayerId(user.getId())).thenReturn(Optional.of(activeLobby));
+
+        DuelException exception =
+                assertThrows(DuelException.class, () -> partyManager.joinParty(user.getId(), partyCode));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus().orElseThrow());
+        assertEquals("You are currently in a duel. Please forfeit the duel, then try again.", exception.getMessage());
+
+        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
+        verify(lobbyRepository, times(0)).updateLobby(any());
+    }
+
+    @Test
+    void testJoinPartyLobbyUpdateFailure() {
+        User user = createRandomUser();
+        String partyCode = "ABC123";
+
+        Lobby mockLobby = Lobby.builder()
+                .id(randomUUID())
+                .joinCode(partyCode)
+                .status(LobbyStatus.AVAILABLE)
+                .expiresAt(StandardizedOffsetDateTime.now().plusHours(1))
+                .playerCount(1)
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyRepository.findAvailableLobbyByJoinCode(partyCode)).thenReturn(Optional.of(mockLobby));
+        when(lobbyRepository.findAvailableLobbyByLobbyPlayerPlayerId(user.getId()))
+                .thenReturn(Optional.empty());
+        when(lobbyRepository.findActiveLobbyByLobbyPlayerPlayerId(user.getId())).thenReturn(Optional.empty());
+        when(lobbyRepository.updateLobby(any(Lobby.class))).thenReturn(false);
+
+        DuelException exception =
+                assertThrows(DuelException.class, () -> partyManager.joinParty(user.getId(), partyCode));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getHttpStatus().orElseThrow());
+        assertEquals("Failed to join party. Please try again later.", exception.getMessage());
+
+        verify(lobbyPlayerRepository, times(1)).createLobbyPlayer(any(LobbyPlayer.class));
+        verify(lobbyRepository, times(1)).updateLobby(any(Lobby.class));
+    }
+
+    @Test
+    void testJoinPartyExpiredLobby() {
+        User user = createRandomUser();
+        String partyCode = "ABC123";
+
+        OffsetDateTime pastTime = OffsetDateTime.now().minusMinutes(5);
+        Lobby expiredLobby = Lobby.builder()
+                .id(randomUUID())
+                .joinCode(partyCode)
+                .status(LobbyStatus.AVAILABLE)
+                .playerCount(1)
+                .expiresAt(pastTime)
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyRepository.findAvailableLobbyByJoinCode(partyCode)).thenReturn(Optional.of(expiredLobby));
+
+        DuelException exception =
+                assertThrows(DuelException.class, () -> partyManager.joinParty(user.getId(), partyCode));
+
+        assertEquals(HttpStatus.GONE, exception.getHttpStatus().orElseThrow());
+        assertEquals("The lobby has expired and cannot be joined.", exception.getMessage());
+
+        verify(lobbyPlayerRepository, times(0)).createLobbyPlayer(any());
+        verify(lobbyRepository, times(0)).updateLobby(any());
+    }
+
+    @Test
+    void testLeavePartySuccessWhenUserInPartyAndLobbyHasMultiplePlayers() throws DuelException {
+        User user = createRandomUser();
+
+        String lobbyId = randomUUID();
+        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
+                .id(randomUUID())
+                .lobbyId(lobbyId)
+                .playerId(user.getId())
+                .points(50)
+                .build();
+
+        Lobby lobby = Lobby.builder()
+                .id(lobbyId)
+                .joinCode("ABC123")
+                .status(LobbyStatus.AVAILABLE)
+                .expiresAt(OffsetDateTime.now().plusMinutes(30))
+                .playerCount(3)
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
+                .thenReturn(Optional.of(existingLobbyPlayer));
+        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
+                .thenReturn(true);
+        when(lobbyRepository.findLobbyById(lobbyId)).thenReturn(Optional.of(lobby));
+
+        partyManager.leaveParty(user.getId());
+
+        verify(lobbyPlayerRepository, times(1)).deleteLobbyPlayerById(existingLobbyPlayer.getId());
+
+        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
+        verify(lobbyRepository, times(1)).updateLobby(lobbyCaptor.capture());
+
+        Lobby updatedLobby = lobbyCaptor.getValue();
+        assertEquals(2, updatedLobby.getPlayerCount());
+        assertEquals(LobbyStatus.AVAILABLE, updatedLobby.getStatus());
+    }
+
+    @Test
+    void testLeavePartySuccessWhenLobbyDoesNotExist() {
+        User user = createRandomUser();
+
+        String lobbyId = randomUUID();
+        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
+                .id(randomUUID())
+                .lobbyId(lobbyId)
+                .playerId(user.getId())
+                .points(50)
+                .build();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
+                .thenReturn(Optional.of(existingLobbyPlayer));
+        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
+                .thenReturn(true);
+        when(lobbyRepository.findLobbyById(lobbyId)).thenReturn(Optional.empty());
+
+        DuelException exception = assertThrows(DuelException.class, () -> partyManager.leaveParty(user.getId()));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getHttpStatus().orElseThrow());
+        assertEquals("Something went wrong.", exception.getMessage());
+
+        verify(lobbyPlayerRepository, times(1)).deleteLobbyPlayerById(existingLobbyPlayer.getId());
+        verify(lobbyRepository, times(0)).updateLobby(any());
+    }
+
+    @Test
+    void testLeavePartyDecreasesPlayerCountCorrectly() throws DuelException {
+        User user = createRandomUser();
+
+        String lobbyId = randomUUID();
+        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
+                .id(randomUUID())
+                .lobbyId(lobbyId)
+                .playerId(user.getId())
+                .points(0)
+                .build();
+
+        Lobby lobby = Lobby.builder()
+                .id(lobbyId)
+                .joinCode("ABC123")
+                .status(LobbyStatus.AVAILABLE)
+                .expiresAt(OffsetDateTime.now().plusMinutes(30))
+                .playerCount(3)
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
+                .thenReturn(Optional.of(existingLobbyPlayer));
+        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
+                .thenReturn(true);
+        when(lobbyRepository.findLobbyById(lobbyId)).thenReturn(Optional.of(lobby));
+
+        partyManager.leaveParty(user.getId());
+
+        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
+        verify(lobbyRepository, times(1)).updateLobby(lobbyCaptor.capture());
+
+        Lobby updatedLobby = lobbyCaptor.getValue();
+        assertEquals(2, updatedLobby.getPlayerCount());
+        assertEquals(LobbyStatus.AVAILABLE, updatedLobby.getStatus());
+    }
+
+    @Test
+    void testLeavePartyFailureWhenUserNotInLobby() {
+        User user = createRandomUser();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId())).thenReturn(Optional.empty());
+
+        DuelException exception = assertThrows(DuelException.class, () -> partyManager.leaveParty(user.getId()));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getHttpStatus().orElseThrow());
+        assertEquals("You are not currently in a lobby.", exception.getMessage());
+
+        verify(lobbyPlayerRepository, times(0)).deleteLobbyPlayerById(any());
+        verify(lobbyRepository, times(0)).updateLobby(any());
+    }
+
+    @Test
+    void testLeavePartyFailureWhenDeletionFails() {
+        User user = createRandomUser();
+
+        String lobbyId = randomUUID();
+        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
+                .id(randomUUID())
+                .lobbyId(lobbyId)
+                .playerId(user.getId())
+                .points(50)
+                .build();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
+                .thenReturn(Optional.of(existingLobbyPlayer));
+        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
+                .thenReturn(false);
+
+        DuelException exception = assertThrows(DuelException.class, () -> partyManager.leaveParty(user.getId()));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getHttpStatus().orElseThrow());
+        assertEquals("Failed to leave lobby. Please try again.", exception.getMessage());
+
+        verify(lobbyPlayerRepository, times(1)).deleteLobbyPlayerById(existingLobbyPlayer.getId());
+        verify(lobbyRepository, times(0)).findLobbyById(any());
+        verify(lobbyRepository, times(0)).updateLobby(any());
+    }
+
+    @Test
+    void testLeavePartySetsLobbyToClosedWhenLastPlayerLeaves() throws DuelException {
+        User user = createRandomUser();
+
+        String lobbyId = randomUUID();
+        LobbyPlayer existingLobbyPlayer = LobbyPlayer.builder()
+                .id(randomUUID())
+                .lobbyId(lobbyId)
+                .playerId(user.getId())
+                .points(0)
+                .build();
+
+        Lobby lobby = Lobby.builder()
+                .id(lobbyId)
+                .joinCode("ABC123")
+                .status(LobbyStatus.AVAILABLE)
+                .expiresAt(OffsetDateTime.now().plusMinutes(30))
+                .playerCount(1)
+                .winnerId(Optional.empty())
+                .build();
+
+        when(lobbyPlayerRepository.findValidLobbyPlayerByPlayerId(user.getId()))
+                .thenReturn(Optional.of(existingLobbyPlayer));
+        when(lobbyPlayerRepository.deleteLobbyPlayerById(existingLobbyPlayer.getId()))
+                .thenReturn(true);
+        when(lobbyRepository.findLobbyById(lobbyId)).thenReturn(Optional.of(lobby));
+
+        partyManager.leaveParty(user.getId());
+
+        ArgumentCaptor<Lobby> lobbyCaptor = ArgumentCaptor.forClass(Lobby.class);
+        verify(lobbyRepository, times(1)).updateLobby(lobbyCaptor.capture());
+
+        Lobby updatedLobby = lobbyCaptor.getValue();
+        assertEquals(0, updatedLobby.getPlayerCount());
+        assertEquals(LobbyStatus.CLOSED, updatedLobby.getStatus());
+    }
+}


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [536](https://codebloom.notion.site/Refactor-a-lot-of-DuelController-logic-into-DuelManager-2d47c85563aa80c1bcfde997786f2ae4)

## Description of changes

- The party logic inside of DuelController has been refactored into a new PartyManager (keeping separate from DuelManager to avoid having one huge class). 
- There were also some small updates to distinguish between the types within the `Lobby` table. There are now parties and duels, which are application-level terms. They are still derived from the `Lobby` db table. 

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [ ] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

<img width="550" height="882" alt="image" src="https://github.com/user-attachments/assets/a7aa9290-e12c-4762-abb3-bd570f966f04" />

### Staging

create:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/10438769-3f44-425f-9997-aa4a28e53ad8" />
join but cant join anything bc in party:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/67be7d25-129e-4431-bd84-40104dba4aff" />
start duel (admin override):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a19e4fb6-c47c-4e6b-8ffe-0105be2506f5" />
cant create lobby while in duel:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a79671c0-333d-4c31-abf9-f0911144f710" />
duel not ready to expire yet:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ebb46700-b640-4c48-a24d-174e71aabf1f" />
duel ended after manually set to expired in db:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/807634ef-cad5-4188-bf85-b17308583d1c" />
create after duel ended:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b93eda8e-5ef7-47c0-9599-da1f5a2e0565" />






