### PR TITLE
540: Add logic to fail PRs if below 80% min code coverage

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -83,6 +83,14 @@ jobs:
                 token: ${{ secrets.GITHUB_TOKEN }}
                 min-coverage-overall: 40
                 min-coverage-changed-files: 80
+            
+            - name: Fail PR if changed files coverage is less than 80%
+              if: ${{ steps.jacoco.outputs.coverage-changed-files < 80.0 }}
+              uses: actions/github-script@v6
+              with:
+                script: |
+                  core.setFailed('Changed files test coverage is below 80%. Please add or update tests for any new code to meet the required coverage threshold.')
+                
 
     frontendTests:
         name: Frontend Tests


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [540](https://codebloom.notion.site/Add-logic-to-fail-PRs-if-below-80-min-code-coverage-2d67c85563aa807285affef557711233)

## Description of changes

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots


<img width="872" height="303" alt="Screenshot 2025-12-28 at 8 20 37 PM" src="https://github.com/user-attachments/assets/af105bdb-5424-496a-a6bf-a811f1f4e3d2" />
<img width="1167" height="759" alt="Screenshot 2025-12-28 at 8 20 24 PM" src="https://github.com/user-attachments/assets/05c24bf3-654d-46c2-9321-bf2ae7d36344" />
