### PR TITLE
506: Add db column to leaderboard name to indicate whether to render w syntax highlighting or not

### DIFF
--- a/db/migration/V0062__Add_shouldRenderWithSyntaxHighlighting_to_leaderboard.SQL
+++ b/db/migration/V0062__Add_shouldRenderWithSyntaxHighlighting_to_leaderboard.SQL
@@ -1,0 +1,4 @@
+ALTER TABLE
+    "Leaderboard"
+ADD
+    COLUMN "syntaxHighlightingLanguage" TEXT NULL;

--- a/db/migration/V0063__Set_syntaxHighlighting_for_existing_leaderboards.SQL
+++ b/db/migration/V0063__Set_syntaxHighlighting_for_existing_leaderboards.SQL
@@ -1,0 +1,17 @@
+UPDATE
+    "Leaderboard"
+SET
+    "syntaxHighlightingLanguage" = 'java'
+WHERE
+    name IN (
+        'double december = 12.0d;',
+        'new Stack("September")',
+        '"july".split("")'
+    );
+
+UPDATE
+    "Leaderboard"
+SET
+    "syntaxHighlightingLanguage" = 'cpp'
+WHERE
+    name = 'auto november = nullptr;';


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [506](https://codebloom.notion.site/Add-db-column-to-leaderboard-name-to-indicate-whether-to-render-w-syntax-highlighting-or-not-2bc7c85563aa809baf7de585f51b2057)

## Description of changes
added columns for syntaxHighlightingLanguage
- wrote script to check the past / current leaderboard thats in the db already 
## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev
<img width="1020" height="702" alt="Screenshot 2025-12-28 at 11 39 35 PM" src="https://github.com/user-attachments/assets/0f5e7472-99b9-4357-b3a7-6f48c5a38493" />
