### PR TITLE
553: Allowed X-Frames on the embed endpoints

### DIFF
--- a/src/main/java/com/patina/codebloom/api/auth/security/SecurityConfig.java
+++ b/src/main/java/com/patina/codebloom/api/auth/security/SecurityConfig.java
@@ -53,13 +53,24 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    @Order(2)
+    SecurityFilterChain embedSecurity(HttpSecurity http) throws Exception {
+        http.securityMatcher("/embed/potd", "/embed/leaderboard")
+                .headers(headers -> headers.frameOptions(f -> f.sameOrigin())
+                        .contentSecurityPolicy(csp -> csp.policyDirectives("frame-ancestors *")))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+
+        return http.build();
+    }
+
     /**
      * The authorization endpoint is used to get redirected to the OAuth login page. The redirection endpoint is the
      * callback endpoint on our server that then handles the authentication logic. This handles all other requests with
      * OAuth.
      */
     @Bean
-    @Order(2)
+    @Order(3)
     public SecurityFilterChain oauthSecurityFilterChain(final HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [553](https://codebloom.notion.site/Add-X-Frame-Options-header-for-embedded-urls-and-generate-codepen-io-url-for-Patina-embeds-2d77c85563aa80309393f7ecfed18763)

## Description of changes

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

Only relevant for non-local iframing

### Staging

<img width="417" height="649" alt="image" src="https://github.com/user-attachments/assets/10b975f8-320f-4385-9369-100f586e9ee8" />