### PR TITLE
606: leetcodeUsername should only be removed from admin users

### DIFF
--- a/infra/copy-prod-db.sh
+++ b/infra/copy-prod-db.sh
@@ -58,9 +58,14 @@ PGPASSWORD="$DATABASE_PASSWORD" psql \
         WHEN \"schoolEmail\" IS NOT NULL THEN 'test_' || encode(gen_random_bytes(4), 'hex') || '@example.com'
         ELSE NULL 
       END,
-      \"profileUrl\" = 'https://via.placeholder.com/150',
-      \"leetcodeUsername\" = NULL
+      \"profileUrl\" = 'https://via.placeholder.com/150'
     WHERE \"admin\" IS NOT TRUE;
+
+    -- Scramble admin user data
+    UPDATE \"User\" 
+    SET 
+      \"leetcodeUsername\" = NULL
+    WHERE \"admin\" IS TRUE;
 
     -- Update DiscordClubMetadata for 'Patina Network'
     UPDATE \"DiscordClubMetadata\" m


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [606](https://codebloom.notion.site/Fix-copy-stg-script-to-only-remove-leetcodeUsername-from-admin-users-2e17c85563aa80b49df7dec5dd9b42d7)

## Description of changes

Update copy to staging script so leetcodeUsername should only be removed from admin users


## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

Cannot test in dev

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->