### PR TITLE
614:  Fix off by one error in staging deployment workflow

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -468,11 +468,11 @@ jobs:
                       const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
                       const commitHash = '${{ needs.getPRHead.outputs.sha }}';
 
-                      const results = ${{ toJSON(needs.*.result) }};
-                      const jobNames = ['getPRHead', 'checkExistingImage', 'sendMessage', 'backendTests', 'backendPreTest', 'frontendTests', 'validateDBSchema', 'buildImage', 'promoteExisting', 'redeploy'];
-                      const failedJobs = jobNames.filter((name, index) => results[index] === 'failure');
-                      const cancelledJobs = jobNames.filter((name, index) => results[index] === 'cancelled');
-                      const successJobs = jobNames.filter((name, index) => results[index] === 'success');
+                      const needsObj = ${{ toJSON(needs) }};
+                      const jobNames = Object.keys(needsObj);
+                      const failedJobs = jobNames.filter((name) => needsObj[name].result === 'failure');
+                      const cancelledJobs = jobNames.filter((name) => needsObj[name].result === 'cancelled');
+                      const successJobs = jobNames.filter((name) => needsObj[name].result === 'success');
 
                       let statusMessage;
                       if (failedJobs.length > 0 && cancelledJobs.length > 0) {


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [614](https://codebloom.notion.site/Fix-bug-where-staging-deployment-succeeds-even-though-redeploy-step-fails-2e17c85563aa8014885be88ec56f0287)

## Description of changes

- Add missing job to jobNames (backendPreTest is in needs array, but not here causing an off by one error)

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

<img width="1036" height="79" alt="image" src="https://github.com/user-attachments/assets/81356b6c-3df1-43da-8162-53d860002c07" />


