### PR TITLE
618: Add 5ms delay between update loop of startDate v endDate in useURLDateRange

### DIFF
--- a/js/src/lib/hooks/useURLDateRange.ts
+++ b/js/src/lib/hooks/useURLDateRange.ts
@@ -10,6 +10,10 @@ type DateRangeStateObject = {
   debouncedStartDate: string | undefined;
 };
 
+// See 618: Hacky solution to stagger the render loop between startDate and endDate
+// so that they don't work with stale data and override each other.
+const STAGGER_MS = 5;
+
 /**
  * Wrapper over {@code useURLState} that allows empty date ranges in URL but is represented
  * as `undefined` within the codebase.
@@ -31,9 +35,7 @@ export default function useURLDateRange(
     "",
     {
       enabled,
-      // See 618: Hacky solution to stagger the render loop between startDate and endDate
-      // so that they don't work with stale data and override each other.
-      debounce: debounce + 5,
+      debounce: Math.max(0, debounce),
     },
   );
   const [_endDate, _setEndDate, _debouncedEndDate] = useURLState<string>(
@@ -41,9 +43,7 @@ export default function useURLDateRange(
     "",
     {
       enabled,
-      // See 618: Hacky solution to stagger the render loop between startDate and endDate
-      // so that they don't work with stale data and override each other.
-      debounce: debounce - 5,
+      debounce: Math.max(0, debounce) + STAGGER_MS,
     },
   );
 


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [618](https://codebloom.notion.site/Fix-bug-where-startDate-and-endDate-are-not-reflecting-correctly-in-URL-in-user-submissions-page-2e17c85563aa800b8121f8dab22eef5b)

## Description of changes

- Add 5ms delay between update loop of startDate v endDate in useURLDateRange

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

https://github.com/user-attachments/assets/d5736b2c-72d8-4b72-b711-59338335eb8c

### Staging

https://github.com/user-attachments/assets/810cc13c-d337-4062-b214-c3b129a99dd6