### PR TITLE
617: Embed leaderboard will open all links in new tab

### DIFF
--- a/js/src/app/embed/leaderboard/_components/OrgEmbedView.tsx
+++ b/js/src/app/embed/leaderboard/_components/OrgEmbedView.tsx
@@ -82,8 +82,8 @@ export default function OrgLeaderboardEmbed() {
       <OrgHeader orgTag={activeFilter} />
       <Center mb="xs">
         <Button
-          component="a"
-          href="https://codebloom.patinanetwork.org"
+          component={Link}
+          to="/"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -180,6 +180,9 @@ export default function OrgLeaderboardEmbed() {
                       direction={"column"}
                       component={Link}
                       to={`/user/${entry.id}`}
+                      reloadDocument
+                      target="_blank"
+                      rel="noopener noreferrer"
                       className="group"
                     >
                       {entry.nickname ?


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [617](https://codebloom.notion.site/All-Links-inside-of-embed-leaderboard-should-open-new-tab-2e17c85563aa80eca913f7a6bdce5de1)

## Description of changes

- Update embed leaderboard so all links open in new tab

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

Not necessary

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->