### PR TITLE
617: Update cards to open user profiles in new tab if embedded

### DIFF
--- a/js/src/components/ui/LeaderboardCard.tsx
+++ b/js/src/components/ui/LeaderboardCard.tsx
@@ -87,6 +87,9 @@ export default function LeaderboardCard({
       }}
       component={Link}
       to={`/user/${userId}`}
+      reloadDocument={embedded}
+      target={embedded ? "_blank" : undefined}
+      rel={embedded ? "noopener noreferrer" : undefined}
     >
       <LoadingOverlay visible={isLoading} />
       <Text


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [617](https://codebloom.notion.site/All-Links-inside-of-embed-leaderboard-should-open-new-tab-2e17c85563aa80eca913f7a6bdce5de1)

## Description of changes

- Update cards to open user profiles in new tab if embedded

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

https://github.com/user-attachments/assets/10c842e5-f8c7-4992-b663-aa54f1f27912

### Staging

https://github.com/user-attachments/assets/df05f6da-bc2a-4597-84db-0c445ab0ab40