### PR TITLE
596: testing failure

### DIFF
--- a/.github/composite/check-notion-commits/action.yml
+++ b/.github/composite/check-notion-commits/action.yml
@@ -62,5 +62,5 @@ runs:
       if: steps.verify.outcome == 'failure'
       shell: bash
       run: |
-        echo "One or more commits do not match the Notion ID"
+        echo "One or more commits do not match the Notion ID."
         exit 1

--- a/.github/composite/check-notion-pr/action.yml
+++ b/.github/composite/check-notion-pr/action.yml
@@ -42,10 +42,11 @@ runs:
         set -euo pipefail
 
         TITLE="$(gh pr view "${{ inputs.PR_ID }}" --json title -q .title)"
-        PREFIX="$(echo "$TITLE" | grep -oE '^-?[0-9]+')"
+        PREFIX="$(echo "$TITLE" | grep -oE '^-?[0-9]+' || true)"
 
         if [ -z "$PREFIX" ]; then
           echo "No numeric prefix found in PR title: $TITLE" >&2
+          echo "status=failed" >> "$GITHUB_OUTPUT"
           exit 1
         fi
 
@@ -166,6 +167,18 @@ runs:
         prId: ${{ inputs.PR_ID }}
         message: |
           Task ID ${{ steps.parse_id.outputs.id || 'N/A'}} does not exist on Notion. Please set a valid Notion task ID to the start of the PR title.
+
+    - name: Send a message to the PR if title does not have number prefix
+      if: failure() && steps.parse_id.outcome == 'failure'
+      uses: ./.github/composite/send-message
+      with:
+        prId: ${{ inputs.PR_ID }}
+        message: |
+          ## TITLE ID REQUIRED
+
+          Please add the ID of your Notion ticket to the title of the PR. 
+
+          **Example:** `420: Foo Bar`
 
     - name: Fail if task does not exist
       if: steps.check_notion.outputs.found == 'false'


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [596](https://codebloom.notion.site/Notion-verify-PR-step-fails-but-outputs-no-PR-message-2df7c85563aa8006bf62deb4c3fe2a7e)

## Description of changes

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [ ] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev
<img width="971" height="329" alt="Screenshot 2026-01-11 at 1 33 19 PM" src="https://github.com/user-attachments/assets/84278b6a-b3e4-4698-9f5d-a89f60ee3aa8" />

<!-- Screenshots go here -->

### Staging
Unnecessary (this is a workflow change)
<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->