### PR TITLE
636: Added PR Help Comment

### DIFF
--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -17,20 +17,19 @@ jobs:
     
     steps:
       - name: Help Comment
-        uses: actions/github-script@v7
+        uses: actions/checkout@v4
+      
+      - name: Send PR Help Message
+        uses: ./.github/composite/send-message
         with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Available PR Commands:
+          prId: ${{ github.event.pull_request.number }}
+          message: |
+            ### Available PR Commands
             
-            - \`/ai\` - Triggers all AI review commands at once
-            - \`/review\` - AI review of the PR changes
-            - \`/describe\` - AI-powered description of the PR
-            - \`/improve\` - AI-powered suggestions
-            - \`/deploy\` - Deploy to staging
+            - `/ai` - Triggers all AI review commands at once
+            - `/review` - AI review of the PR changes
+            - `/describe` - AI-powered description of the PR
+            - `/improve` - AI-powered suggestions
+            - `/deploy` - Deploy to staging
             
-            See: https://github.com/tahminator/codebloom/wiki/CI-Commands`
-            });
+            See: https://github.com/tahminator/codebloom/wiki/CI-Commands


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [636](https://codebloom.notion.site/Add-PR-help-comment-available-PR-commands-in-wiki-2e27c85563aa807bb4f8f56be875ed7d)

## Description of changes

Added PR Help Comment to display the different available PR commands on the wiki site

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

<img width="1470" height="956" alt="Screenshot 2026-01-14 at 8 38 00 PM" src="https://github.com/user-attachments/assets/a3e8973c-de96-4e73-87ac-0a2a7a257ee3" />

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->

I just have to test that the help comment shows when a PR is opened, not necessarily in staging.