### PR TITLE
636: Created help comment command

### DIFF
--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -6,8 +6,6 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
-  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
## [636](https://codebloom.notion.site/Add-PR-help-comment-available-PR-commands-in-wiki-2e27c85563aa807bb4f8f56be875ed7d)

## Description of changes

- Created help-command.yml to display helpful wiki commands when PR is first opened

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

<img width="1470" height="956" alt="Screenshot 2026-01-15 at 11 19 04 AM" src="https://github.com/user-attachments/assets/bd121bf5-f61d-4e15-aab6-28abf14ebc11" />

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->

Not needed, as AC was to see if help command shows up when PR is opened
