### PR TITLE
593: Clicking on user profile from leaderboard page should use date range params

### DIFF
--- a/js/src/app/_component/MiniLeaderboard.tsx
+++ b/js/src/app/_component/MiniLeaderboard.tsx
@@ -6,6 +6,7 @@ import { useCurrentLeaderboardUsersQuery } from "@/lib/api/queries/leaderboard";
 import { Tag } from "@/lib/api/types/autogen/schema";
 import { tagFF } from "@/lib/ff";
 import getOrdinal from "@/lib/helper/ordinal";
+import { useLeaderboardSubmissionsUrl } from "@/lib/hooks/useLeaderboardSubmissionsUrl";
 import { theme } from "@/lib/theme";
 import {
   Button,
@@ -25,6 +26,9 @@ import { Link } from "react-router-dom";
 export default function MiniLeaderboardDesktop() {
   const { data, status, filters, toggleFilter, isPlaceholderData } =
     useCurrentLeaderboardUsersQuery({ pageSize: 5, tieToUrl: false });
+
+  const { getUserSubmissionsUrl, startDate, endDate } =
+    useLeaderboardSubmissionsUrl();
 
   if (status === "pending") {
     return <MiniLeaderboardSkeleton />;
@@ -85,6 +89,8 @@ export default function MiniLeaderboardDesktop() {
               width={"200px"}
               userId={second.id}
               isLoading={isPlaceholderData}
+              startDate={startDate}
+              endDate={endDate}
             />
           )}
           {first && (
@@ -98,6 +104,8 @@ export default function MiniLeaderboardDesktop() {
               width={"200px"}
               userId={first.id}
               isLoading={isPlaceholderData}
+              startDate={startDate}
+              endDate={endDate}
             />
           )}
           {third && (
@@ -111,6 +119,8 @@ export default function MiniLeaderboardDesktop() {
               width={"200px"}
               userId={third.id}
               isLoading={isPlaceholderData}
+              startDate={startDate}
+              endDate={endDate}
             />
           )}
         </Flex>
@@ -122,7 +132,7 @@ export default function MiniLeaderboardDesktop() {
                 <Card
                   key={entry.id}
                   component={Link}
-                  to={`/user/${entry.id}`}
+                  to={getUserSubmissionsUrl(entry.id)}
                   withBorder
                   radius="md"
                   padding="lg"

--- a/js/src/app/_component/MiniLeaderboardMobile.tsx
+++ b/js/src/app/_component/MiniLeaderboardMobile.tsx
@@ -4,6 +4,7 @@ import Toast from "@/components/ui/toast/Toast";
 import { useCurrentLeaderboardUsersQuery } from "@/lib/api/queries/leaderboard";
 import { Tag } from "@/lib/api/types/autogen/schema";
 import getOrdinal from "@/lib/helper/ordinal";
+import { useLeaderboardSubmissionsUrl } from "@/lib/hooks/useLeaderboardSubmissionsUrl";
 import { theme } from "@/lib/theme";
 import {
   Button,
@@ -22,6 +23,9 @@ import { Link } from "react-router-dom";
 export default function MiniLeaderboardMobile() {
   const { data, status, filters, toggleFilter, isPlaceholderData } =
     useCurrentLeaderboardUsersQuery({ pageSize: 5, tieToUrl: false });
+
+  const { getUserSubmissionsUrl, startDate, endDate } =
+    useLeaderboardSubmissionsUrl();
 
   if (status === "pending") {
     return <MiniLeaderboardMobileSkeleton />;
@@ -83,6 +87,8 @@ export default function MiniLeaderboardMobile() {
               width={"300px"}
               userId={first.id}
               isLoading={isPlaceholderData}
+              startDate={startDate}
+              endDate={endDate}
             />
           )}
           {second && (
@@ -96,6 +102,8 @@ export default function MiniLeaderboardMobile() {
               width={"300px"}
               userId={second.id}
               isLoading={isPlaceholderData}
+              startDate={startDate}
+              endDate={endDate}
             />
           )}
           {third && (
@@ -109,6 +117,8 @@ export default function MiniLeaderboardMobile() {
               width={"300px"}
               userId={third.id}
               isLoading={isPlaceholderData}
+              startDate={startDate}
+              endDate={endDate}
             />
           )}
         </Flex>
@@ -120,7 +130,7 @@ export default function MiniLeaderboardMobile() {
                 <Card
                   key={entry.id}
                   component={Link}
-                  to={`/user/${entry.id}`}
+                  to={getUserSubmissionsUrl(entry.id)}
                   withBorder
                   radius="md"
                   padding="lg"

--- a/js/src/app/leaderboard/_components/Leaderboard.tsx
+++ b/js/src/app/leaderboard/_components/Leaderboard.tsx
@@ -13,6 +13,7 @@ import {
 import { ApiUtils } from "@/lib/api/utils";
 import { schoolFF, tagFF } from "@/lib/ff";
 import getOrdinal from "@/lib/helper/ordinal";
+import { useLeaderboardSubmissionsUrl } from "@/lib/hooks/useLeaderboardSubmissionsUrl";
 import { theme } from "@/lib/theme";
 import {
   Box,
@@ -64,9 +65,10 @@ function LeaderboardIndex({
     globalIndex,
     toggleGlobalIndex,
     isPlaceholderData,
-    isAnyFilterEnabled,
-    onFilterReset,
-  } = query;
+  } = useCurrentLeaderboardUsersQuery();
+
+  const { getUserSubmissionsUrl, startDate, endDate } =
+    useLeaderboardSubmissionsUrl();
 
   if (status === "pending") {
     return <LeaderboardSkeleton />;
@@ -120,6 +122,8 @@ function LeaderboardIndex({
             userId={second.id}
             tags={second.tags}
             isLoading={isPlaceholderData}
+            startDate={startDate}
+            endDate={endDate}
           />
         )}
         {page === 1 && first && !debouncedQuery && (
@@ -134,6 +138,8 @@ function LeaderboardIndex({
             userId={first.id}
             tags={first.tags}
             isLoading={isPlaceholderData}
+            startDate={startDate}
+            endDate={endDate}
           />
         )}
         {page === 1 && third && !debouncedQuery && (
@@ -148,6 +154,8 @@ function LeaderboardIndex({
             userId={third.id}
             tags={third.tags}
             isLoading={isPlaceholderData}
+            startDate={startDate}
+            endDate={endDate}
           />
         )}
       </Flex>
@@ -222,7 +230,7 @@ function LeaderboardIndex({
             <PossibleTooltip key={entry.id}>
               <Card
                 component={Link}
-                to={isPrevious ? "#" : `/user/${entry.id}`}
+                to={isPrevious ? "#" : getUserSubmissionsUrl(entry.id)}
                 shadow="sm"
                 padding="lg"
                 radius="md"

--- a/js/src/components/ui/LeaderboardCard.tsx
+++ b/js/src/components/ui/LeaderboardCard.tsx
@@ -29,6 +29,8 @@ export default function LeaderboardCard({
   tags,
   isLoading = false,
   embedded = false,
+  startDate,
+  endDate,
 }: {
   placeString: OrdinalString;
   sizeOrder: 1 | 2 | 3;
@@ -41,6 +43,8 @@ export default function LeaderboardCard({
   tags?: UserTag[];
   isLoading?: boolean;
   embedded?: boolean;
+  startDate?: string;
+  endDate?: string;
 }) {
   const isTopThree = sizeOrder <= 3;
   const borderColor = (() => {
@@ -72,6 +76,18 @@ export default function LeaderboardCard({
   })();
   const displayTags = tags?.slice(0, 3);
 
+  const getUserSubmissionsUrl = () => {
+    const params = new URLSearchParams();
+    if (startDate) {
+      params.set("startDate", startDate);
+    }
+    if (endDate) {
+      params.set("endDate", endDate);
+    }
+    const queryString = params.toString();
+    return `/user/${userId}/submissions${queryString ? `?${queryString}` : ""}`;
+  };
+
   return (
     <Card
       withBorder
@@ -85,7 +101,7 @@ export default function LeaderboardCard({
         boxShadow,
       }}
       component={Link}
-      to={`/user/${userId}`}
+      to={getUserSubmissionsUrl()}
       reloadDocument={embedded}
       target={embedded ? "_blank" : undefined}
       rel={embedded ? "noopener noreferrer" : undefined}

--- a/js/src/lib/hooks/useLeaderboardSubmissionsUrl.ts
+++ b/js/src/lib/hooks/useLeaderboardSubmissionsUrl.ts
@@ -1,0 +1,76 @@
+import {
+  useCurrentLeaderboardMetadataQuery,
+  useLeaderboardMetadataByIdQuery,
+} from "@/lib/api/queries/leaderboard";
+import { useCallback } from "react";
+
+/**
+ * React hook that provides a function to generate user submissions URLs
+ * with leaderboard date range parameters.
+ *
+ * @param {Object} options - Configuration options for the hook.
+ * @param {string} options.leaderboardId - (Optional) The leaderboard ID to fetch metadata for.
+ *   If not provided, uses the current active leaderboard.
+ *
+ * @returns An object containing:
+ * - `getUserSubmissionsUrl`: a function that takes a userId and returns the submissions URL with date params
+ * - `startDate`: the leaderboard start date (createdAt), or undefined if not loaded
+ * - `endDate`: the leaderboard end date (shouldExpireBy), or undefined if not loaded
+ *
+ * @example
+ * ```tsx
+ * // For current leaderboard
+ * const { getUserSubmissionsUrl, startDate, endDate } = useLeaderboardSubmissionsUrl();
+ *
+ * // For specific leaderboard
+ * const { getUserSubmissionsUrl, startDate, endDate } = useLeaderboardSubmissionsUrl({
+ *   leaderboardId: "some-id"
+ * });
+ *
+ * return (
+ *   <Link to={getUserSubmissionsUrl(userId)}>View Submissions</Link>
+ * );
+ * ```
+ */
+export function useLeaderboardSubmissionsUrl(
+  options: { leaderboardId?: string } = {},
+) {
+  const { leaderboardId } = options;
+
+  const currentLeaderboardQuery = useCurrentLeaderboardMetadataQuery();
+  const leaderboardByIdQuery = useLeaderboardMetadataByIdQuery(
+    leaderboardId ?? "",
+  );
+
+  const metadataData = leaderboardId
+    ? leaderboardByIdQuery.data
+    : currentLeaderboardQuery.data;
+
+  const startDate =
+    metadataData?.success ? metadataData.payload.createdAt : undefined;
+  const endDate =
+    metadataData?.success
+      ? (metadataData.payload.shouldExpireBy ?? undefined)
+      : undefined;
+
+  const getUserSubmissionsUrl = useCallback(
+    (userId: string) => {
+      const params = new URLSearchParams();
+      if (startDate) {
+        params.set("startDate", startDate);
+      }
+      if (endDate) {
+        params.set("endDate", endDate);
+      }
+      const queryString = params.toString();
+      return `/user/${userId}/submissions${queryString ? `?${queryString}` : ""}`;
+    },
+    [startDate, endDate],
+  );
+
+  return {
+    getUserSubmissionsUrl,
+    startDate,
+    endDate,
+  };
+}


### PR DESCRIPTION
… possible leaderboards when clicking on user profile
## [593](https://codebloom.notion.site/Clicking-on-user-profile-from-leaderboard-page-should-use-date-range-params-2df7c85563aa80d19fc8df10e32ba366)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
