### PR TITLE
647: Make deploy to stg status clickable to view latest action

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -281,7 +281,7 @@ jobs:
                         statusMessage = `**Staging deployment was cancelled** for commit ${commitHash}`;
                         status = false;
                       } else {
-                        statusMessage = `**Staging deployment succeeded** for commit ${commitHash}`;
+                        statusMessage = `**[Staging deployment succeeded](${runUrl})** for commit ${commitHash}`;
                         status = true;
                       }
 
@@ -293,6 +293,7 @@ jobs:
                         state: status ? 'success' : 'failure',
                         context: "Successful deployment to staging",
                         description: status ? undefined : "Successful deployment to staging is required",
+                        target_url: runUrl,
                       });
 
                       await github.rest.issues.createComment({


### PR DESCRIPTION

<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
