### PR TITLE
647: Make deploy to stg status clickable to view latest action

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -70,6 +70,16 @@ jobs:
                           body: `The command to deploy to staging for the commit ${commitHash} has been triggered. [View action run](${runUrl})`
                       });
 
+                      await github.rest.repos.createCommitStatus({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          sha: commitHash,
+                          state: 'pending',
+                          target_url: runUrl,
+                          context: 'Deploy to staging',
+                          description: 'Deployment to staging in progress...',
+                      });
+
     checkExistingImage:
         name: Check if image already exists
         runs-on: ubuntu-latest
@@ -291,7 +301,8 @@ jobs:
                         repo: context.repo.repo,
                         sha: commitHash,
                         state: status ? 'success' : 'failure',
-                        context: "Successful deployment to staging",
+                        target_url: runUrl,
+                        context: "Deploy to staging",
                         description: status ? undefined : "Successful deployment to staging is required",
                       });
 


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes
- added target Url 
- Added pending status block to be able to see the deployment as when it triggers

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

https://github.com/user-attachments/assets/03e49dff-21fc-4660-8080-77b240233f13


