### PR TITLE
698: Added "view full leaderboard" message to both weekly update and …

### DIFF
--- a/src/main/java/org/patinanetwork/codebloom/common/components/DiscordClubManager.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/components/DiscordClubManager.java
@@ -113,6 +113,8 @@ public class DiscordClubManager {
 
                 The new leaderboard just started, so best of luck to everyone!
 
+                View the full leaderboard for %s users at https://codebloom.patinanetwork.org/leaderboard?%s=true
+
                 Happy LeetCoding,
                 Codebloom
                 <%s>
@@ -133,6 +135,8 @@ public class DiscordClubManager {
                             .map(UserWithScore::getTotalScore)
                             .map(String::valueOf)
                             .orElse("N/A"),
+                    club.getName(),
+                    club.getTag().name().toLowerCase(),
                     serverUrlUtils.getUrl());
 
             var guildId = club.getDiscordClubMetadata().flatMap(DiscordClubMetadata::getGuildId);
@@ -202,6 +206,8 @@ public class DiscordClubManager {
 
                 Just as a reminder, there's %d day(s), %d hour(s), and %d minute(s) left until the leaderboard closes, so keep grinding!
 
+                View the full leaderboard for %s users at https://codebloom.patinanetwork.org/leaderboard?%s=true
+
 
                 See you next week!
 
@@ -228,6 +234,8 @@ public class DiscordClubManager {
                     daysLeft,
                     hoursLeft,
                     minutesLeft,
+                    club.getName(),
+                    club.getTag().name().toLowerCase(),
                     serverUrlUtils.getUrl());
 
             var guildId = club.getDiscordClubMetadata().flatMap(DiscordClubMetadata::getGuildId);


### PR DESCRIPTION
## [698](https://codebloom.notion.site/Update-bot-leaderboard-embed-to-include-a-link-to-their-specific-leaderboard-2f67c85563aa805bbee0ca9d98724081)
…completed embed messages

<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

Updated the Discord embed message to include the following line:

```View the full leaderboard for {clubName} users at https://codebloom.patinanetwork.org/leaderboard?{tag}=true```

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

New Leaderboard message:
<img width="411" height="703" alt="image" src="https://github.com/user-attachments/assets/53cb6334-8209-496f-b59c-698c07ccbc67" />

Weekly message:
<img width="364" height="714" alt="image" src="https://github.com/user-attachments/assets/5354267b-4a13-48b4-aa5c-183475d3def1" />

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
