### PR TITLE
672: Deploy to staging title should indicate who deployed it

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,5 +1,5 @@
 name: Deploying to staging
-run-name: Deploying to staging
+run-name: Deploying to staging triggered by ${{ github.event.client_payload.github.payload.comment.user.login || github.actor }}
 
 concurrency:
   group: deploy-staging-pr-${{ github.event.client_payload.slash_command.args.named.prId }}


### PR DESCRIPTION
## [672](https://codebloom.notion.site/Deploy-to-staging-title-should-indicate-who-deployed-it-2f07c85563aa80e980dfdaa95d0373c7)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

<img width="1120" height="102" alt="Screenshot 2026-01-30 at 11 38 29 AM" src="https://github.com/user-attachments/assets/7f41d1fe-5871-4584-9179-29b71f153dac" />


<img width="1111" height="270" alt="Screenshot 2026-01-30 at 1 31 06 PM" src="https://github.com/user-attachments/assets/42a9d44f-b651-48cf-8181-28e3e9bbe4f5" />
