### PR TITLE
712: Revert installing only Firefox for Playwright (DESC)

### DIFF
--- a/.github/scripts/test/run-backend-tests.ts
+++ b/.github/scripts/test/run-backend-tests.ts
@@ -29,8 +29,7 @@ async function main() {
 
     await $`./mvnw -B install -D skipTests --no-transfer-progress`;
 
-    await $`./mvnw -B exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps"`;
-    await $`./mvnw -B exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install firefox"`;
+    await $`./mvnw -B exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps"`;
 
     await $`corepack enable pnpm`;
     await $`cd email && pnpm i --frozen-lockfile && ./email.sh && cd ..`;

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -52,8 +52,7 @@ WORKDIR /app
 
 COPY mvnw pom.xml ./
 COPY .mvn/ .mvn/
-RUN ./mvnw -B exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps"
-RUN ./mvnw -B exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install firefox"
+RUN ./mvnw -B exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps"
 COPY --from=backend-build /app/target/*.jar app.jar
 
 ARG SERVER_PROFILES=prod


### PR DESCRIPTION
## [712](https://codebloom.notion.site/Troubleshoot-Leetcode-message-being-sent-repeatedly-in-Patina-leetcode-channel-2fb7c85563aa80e585a0f8440923f36d)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

Playwright is not smart enough to not install all browsers. What happens is that it will try to install all of them at runtime instead, leading to an intense burst of memory usage & crashing our app in the process.

## Checklist before review

- [ ] I have done a thorough self-review of the PR
- [ ] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [ ] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [ ] All tests have passed
- [ ] I have successfully deployed this PR to staging
- [ ] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Before

<img width="2222" height="894" alt="image" src="https://github.com/user-attachments/assets/790659b3-f794-46d3-8f73-ef8f809d326d" />
<img width="1612" height="762" alt="image" src="https://github.com/user-attachments/assets/2e5c5206-b3bb-41dc-aaf5-6378cde7c841" />

### After (in staging)



