### PR TITLE
712: Add more defensive logic to weekly leaderboard messages

### DIFF
--- a/src/main/java/org/patinanetwork/codebloom/common/components/DiscordClubManager.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/components/DiscordClubManager.java
@@ -259,8 +259,7 @@ public class DiscordClubManager {
                     .fileNames(screenshots.stream().map(Pair::getLeft).toList())
                     .build());
         } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
+            log.error("Error in DiscordClubManager when sending weekly leaderboard", e);
         }
     }
 

--- a/src/main/java/org/patinanetwork/codebloom/scheduled/discord/WeeklyLeaderboard.java
+++ b/src/main/java/org/patinanetwork/codebloom/scheduled/discord/WeeklyLeaderboard.java
@@ -34,7 +34,11 @@ public class WeeklyLeaderboard {
         }
 
         log.info("WeeklyLeaderboard triggered.");
-        discordClubManager.sendWeeklyLeaderboardUpdateDiscordMessageToAllClubs();
+        try {
+            discordClubManager.sendWeeklyLeaderboardUpdateDiscordMessageToAllClubs();
+        } catch (Exception e) {
+            log.error("WeeklyLeaderboard failed", e);
+        }
         weeklyMessageRepository.createLatestWeeklyMessage();
     }
 }


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

Add more logic to recover from fatal exceptions when WeeklyLeaderboard fails.

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
