### PR TITLE
722: Double vRAM for production

### DIFF
--- a/.do/specs.ts
+++ b/.do/specs.ts
@@ -59,6 +59,7 @@ export function prodSpec(envs: App_variable_definition[]): App_spec {
     services: [
       {
         ...DIGITALOCEAN_BASE_SERVICE,
+        instanceSizeSlug: "apps-s-1vcpu-2gb",
         image: {
           ...DIGITALOCEAN_BASE_IMAGE,
           tag: "latest",


### PR DESCRIPTION
## [722](https://codebloom.notion.site/Increase-DO-production-app-size-to-stop-OOM-from-creating-new-leaderboard-2fc7c85563aa803395a7ddba4f55f0f4)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

- Double production vRAM capacity (see ticket for reasoning)

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.