### PR TITLE
722: Remove leaderboard images from all Discord leaderboard flows

### DIFF
--- a/src/main/java/org/patinanetwork/codebloom/jda/client/options/EmbeddedImagesMessageOptions.java
+++ b/src/main/java/org/patinanetwork/codebloom/jda/client/options/EmbeddedImagesMessageOptions.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 @Getter
 @Builder
 public class EmbeddedImagesMessageOptions {
-
     private String title;
     private String description;
     private String footerText;
@@ -16,6 +15,10 @@ public class EmbeddedImagesMessageOptions {
     private Color color;
     private long guildId;
     private long channelId;
-    private List<byte[]> filesBytes;
-    private List<String> fileNames;
+
+    @Builder.Default
+    private List<byte[]> filesBytes = List.of();
+
+    @Builder.Default
+    private List<String> fileNames = List.of();
 }


### PR DESCRIPTION
## [722](https://codebloom.notion.site/stop-OOM-from-creating-new-leaderboard-2fc7c85563aa803395a7ddba4f55f0f4)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

- Remove leaderboard images from all Discord leaderboard flows

## Checklist before review

- [ ] I have done a thorough self-review of the PR
- [ ] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [ ] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [ ] All tests have passed
- [ ] I have successfully deployed this PR to staging
- [ ] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<img width="574" height="396" alt="image" src="https://github.com/user-attachments/assets/4bb3be1f-e71e-45f1-bef5-917729a3f0dd" />

### Staging

<img width="621" height="805" alt="image" src="https://github.com/user-attachments/assets/d80dc3b3-d3c1-4991-b1aa-1e8dab5e9569" />

