### PR TITLE
708: align embed leaderboard cards

### DIFF
--- a/js/src/app/embed/leaderboard/_components/OrgEmbedView.tsx
+++ b/js/src/app/embed/leaderboard/_components/OrgEmbedView.tsx
@@ -106,18 +106,18 @@ export default function OrgLeaderboardEmbed() {
         mb="md"
       >
         {page === 1 && second && !debouncedQuery && (
-            <LeaderboardCard
-              placeString={getOrdinal(second.index)}
-              sizeOrder={2}
-              discordName={second.discordName}
-              leetcodeUsername={second.leetcodeUsername}
-              totalScore={second.totalScore}
-              nickname={second.nickname}
-              width={"200px"}
-              userId={second.id as string}
-              isLoading={isPlaceholderData}
-              embedded
-            />
+          <LeaderboardCard
+            placeString={getOrdinal(second.index)}
+            sizeOrder={2}
+            discordName={second.discordName}
+            leetcodeUsername={second.leetcodeUsername}
+            totalScore={second.totalScore}
+            nickname={second.nickname}
+            width={"200px"}
+            userId={second.id as string}
+            isLoading={isPlaceholderData}
+            embedded
+          />
         )}
         {page === 1 && first && !debouncedQuery && (
           <LeaderboardCard


### PR DESCRIPTION
## [708](https://codebloom.notion.site/Embed-leaderboard-cards-are-misaligned-2fa7c85563aa80c2907fe8208dc6b950)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

Aligned the top 3 place cards on resize at /leaderboard/embed 

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

https://github.com/user-attachments/assets/a8964797-6665-46fd-b402-6ba7d9b572f1


### Staging


https://github.com/user-attachments/assets/6f5a1902-e99a-47b1-915f-6e2e99517c2a


