### PR TITLE
749 : Add extra conditions to filter top 3 of leaderboard for discord clubs

### DIFF
--- a/src/main/java/org/patinanetwork/codebloom/common/components/DiscordClubManager.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/components/DiscordClubManager.java
@@ -97,7 +97,7 @@ public class DiscordClubManager {
             String topUsersSection = buildTopUsersSection(users, true);
             String headerText = users.isEmpty()
                     ? "No one claimed a spot on this leaderboard. "
-                    : "CONGRATS ON THE WINNERS FROM THIS LEADERBOARD!";
+                    : "CONGRATS TO THE WINNERS FROM THIS LEADERBOARD!";
 
             String description = String.format(
                     """

--- a/src/test/java/org/patinanetwork/codebloom/common/components/DiscordClubManagerTest.java
+++ b/src/test/java/org/patinanetwork/codebloom/common/components/DiscordClubManagerTest.java
@@ -191,7 +191,7 @@ public class DiscordClubManagerTest {
 
         String description = captor.getValue().getDescription();
         assertTrue(description.contains("No one claimed a spot on this leaderboard"));
-        assertFalse(description.contains("CONGRATS ON THE WINNERS"));
+        assertFalse(description.contains("CONGRATS TO THE WINNERS"));
         assertFalse(description.contains("🥇"));
         assertFalse(description.contains("🥈"));
         assertFalse(description.contains("🥉"));


### PR DESCRIPTION
## [749](https://codebloom.notion.site/Add-extra-conditions-to-filter-top-3-of-leaderboard-2ff7c85563aa80d29689fa4fd9af3688)

<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev
<img width="688" height="423" alt="Screenshot 2026-02-08 at 5 37 50 PM" src="https://github.com/user-attachments/assets/88d032d8-389d-40c0-8b79-f3a578b75bf8" />
<img width="601" height="531" alt="Screenshot 2026-02-08 at 5 19 15 PM" src="https://github.com/user-attachments/assets/cc6b1dab-27c1-46e2-bec2-ec16540834dd" />
<img width="672" height="479" alt="Screenshot 2026-02-08 at 5 18 28 PM" src="https://github.com/user-attachments/assets/267ff5a0-eb1d-4891-9936-2a8e6f8b6361" />
<img width="732" height="531" alt="Screenshot 2026-02-08 at 5 18 12 PM" src="https://github.com/user-attachments/assets/f8725360-885a-4b21-b7ff-9765b3c52f8e" />


### Staging

<img width="614" height="782" alt="Screenshot 2026-02-08 at 6 10 18 PM" src="https://github.com/user-attachments/assets/4e2f4756-76a7-46ec-b75f-b6e67003f332" />
