### PR TITLE
761: Move this week's WeeklyLeaderboard back one day

### DIFF
--- a/db/migration/V0074__Fix_WeeklyLeaderboard_2.SQL
+++ b/db/migration/V0074__Fix_WeeklyLeaderboard_2.SQL
@@ -1,0 +1,16 @@
+DO $$
+BEGIN
+    CASE current_database()
+        WHEN 'codebloom-prod' THEN
+            UPDATE
+                "WeeklyMessage"
+            SET
+                -- previous date 2026-02-09 12:02:01.340315 -05:00
+                -- set to sunday, the 8th
+                "createdAt" = '2026-02-08 12:02:01.340315 -05:00'
+            WHERE
+                id = '91c56b9b-92ed-4528-b6cc-d04c3bb0e2ab';
+        ELSE
+            RAISE NOTICE 'Skipping prod only migration: Current database is %', current_database();
+    END CASE;
+END $$;


### PR DESCRIPTION
## [761](https://codebloom.notion.site/Reset-last-week-s-and-this-week-s-WeeklyLeaderboard-to-Sunday-to-re-align-3027c85563aa8083a5e7c2abdbaa5e34)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

- Move this week's WeeklyLeaderboard back one day

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

Db record I am targetting
<img width="560" height="176" alt="image" src="https://github.com/user-attachments/assets/700fcb2e-42bd-44de-bfb6-463fcfedc37d" />

