### PR TITLE
763: Load .env.shared and .env in dev

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,7 @@ copy-stg *args:
 
 # Run the backend Spring server
 backend-dev *args:
-  dotenvx run -- ./mvnw -Dspring-boot.run.profiles=dev spring-boot:run {{args}}
+  dotenvx run -f .env.shared -f .env -- ./mvnw -Dspring-boot.run.profiles=dev spring-boot:run {{args}}
 
 # Run the backend Spring server with an exposed debugger at :5005
 backend-dev-debug *args:


### PR DESCRIPTION
## [763](https://codebloom.notion.site/Dev-mode-should-merge-env-and-env-shared-together-3027c85563aa80d1b8ffc2743beffdca)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

- Load .env.shared and .env in dev

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

Set `REDIS_URL` in both `.env` and `.env.shared` but `.env` got index 9 and `.env.shared` got index 10

<img width="279" height="167" alt="image" src="https://github.com/user-attachments/assets/ba33b4aa-4cd6-429f-aaac-ed8311109323" />

