### PR TITLE
789: Move @role from embed to message in standup bot

### DIFF
--- a/internal/standup-bot/src/discord/client.rs
+++ b/internal/standup-bot/src/discord/client.rs
@@ -30,6 +30,8 @@ use crate::{
 };
 
 const INTENTS: GatewayIntents = GatewayIntents::GUILD_MEMBERS;
+const ROLE_ID: u64 = 1391944565409316944;
+
 static HTTP: OnceLock<Arc<Http>> = OnceLock::new();
 
 pub async fn init_in_bg(discord_creds: &DiscordCredentials) -> Result<(), Error> {
@@ -66,14 +68,16 @@ pub async fn send_standup_message(discord_creds: &DiscordCredentials) -> Result<
     let embed = CreateEmbed::new()
         .title("Codebloom Standup")
         .description(
-            "<@&1391944565409316944> Standup time! Please leave an update about your latest progress inside of the thread.",
+            "Standup time! Please leave an update about your latest progress inside of the thread.",
         )
         .footer(
             CreateEmbedFooter::new("Codebloom - Internal")
                 .icon_url("https://codebloom.patinanetwork.org/favicon.ico"),
         )
         .colour(Colour::from_rgb(69, 129, 103));
-    let create_msg = CreateMessage::new().embed(embed);
+    let create_msg = CreateMessage::new()
+        .content(format!("<@&{ROLE_ID}>"))
+        .embed(embed);
     let channel = ChannelId::new(discord_creds.channel_id);
 
     let msg = channel


### PR DESCRIPTION
## [789](https://codebloom.notion.site/Move-role-from-embed-to-message-in-standup-bot-3087c85563aa802991dcf6ec439e5153)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

- Move @role from embed to message in standup bot due to the fact that @s inside of the embed message do not cause notifications

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

<img width="673" height="261" alt="image" src="https://github.com/user-attachments/assets/3977bb53-9d63-4d63-8147-4e1dc122d4af" />