### PR TITLE
791: Renamed Client files

### DIFF
--- a/src/main/java/org/patinanetwork/codebloom/api/auth/AuthController.java
+++ b/src/main/java/org/patinanetwork/codebloom/api/auth/AuthController.java
@@ -24,10 +24,10 @@ import org.patinanetwork.codebloom.common.dto.ApiResponder;
 import org.patinanetwork.codebloom.common.dto.Empty;
 import org.patinanetwork.codebloom.common.dto.autogen.UnsafeGenericFailureResponse;
 import org.patinanetwork.codebloom.common.dto.security.AuthenticationObjectDto;
-import org.patinanetwork.codebloom.common.email.client.codebloom.OfficialCodebloomEmail;
+import org.patinanetwork.codebloom.common.email.client.codebloom.OfficialCodebloomEmailClient;
 import org.patinanetwork.codebloom.common.email.error.EmailException;
 import org.patinanetwork.codebloom.common.email.options.SendEmailOptions;
-import org.patinanetwork.codebloom.common.email.template.ReactEmailClient;
+import org.patinanetwork.codebloom.common.email.template.ReactEmailTemplater;
 import org.patinanetwork.codebloom.common.jwt.JWTClient;
 import org.patinanetwork.codebloom.common.lag.FakeLag;
 import org.patinanetwork.codebloom.common.reporter.Reporter;
@@ -65,11 +65,11 @@ public class AuthController {
     private final Protector protector;
     private final JWTClient jwtClient;
     private final UserRepository userRepository;
-    private final OfficialCodebloomEmail emailClient;
+    private final OfficialCodebloomEmailClient emailClient;
     private final ServerUrlUtils serverUrlUtils;
     private final UserTagRepository userTagRepository;
     private final Reporter reporter;
-    private final ReactEmailClient reactEmailClient;
+    private final ReactEmailTemplater reactEmailTemplater;
     private final SimpleRedis<Long> simpleRedis;
 
     public AuthController(
@@ -77,11 +77,11 @@ public class AuthController {
             final Protector protector,
             final JWTClient jwtClient,
             final UserRepository userRepository,
-            final OfficialCodebloomEmail emailClient,
+            final OfficialCodebloomEmailClient emailClient,
             final ServerUrlUtils serverUrlUtils,
             final UserTagRepository userTagRepository,
             final Reporter reporter,
-            final ReactEmailClient reactEmailClient,
+            final ReactEmailTemplater reactEmailTemplater,
             final SimpleRedisProvider simpleRedisProvider) {
         this.sessionRepository = sessionRepository;
         this.protector = protector;
@@ -91,7 +91,7 @@ public class AuthController {
         this.serverUrlUtils = serverUrlUtils;
         this.userTagRepository = userTagRepository;
         this.reporter = reporter;
-        this.reactEmailClient = reactEmailClient;
+        this.reactEmailTemplater = reactEmailTemplater;
         this.simpleRedis = simpleRedisProvider.select(SimpleRedisSlot.VERIFICATION_EMAIL_SENDING);
     }
 
@@ -238,7 +238,7 @@ public class AuthController {
             emailClient.sendMessage(SendEmailOptions.builder()
                     .recipientEmail(email)
                     .subject("Hello from Codebloom!")
-                    .body(reactEmailClient.schoolEmailTemplate(verificationLink))
+                    .body(reactEmailTemplater.schoolEmailTemplate(verificationLink))
                     .build());
             return ResponseEntity.ok()
                     .body(ApiResponder.success("Magic link sent! Check your school inbox to continue.", Empty.of()));

--- a/src/main/java/org/patinanetwork/codebloom/common/email/EmailClient.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/email/EmailClient.java
@@ -10,7 +10,7 @@ import org.patinanetwork.codebloom.common.email.options.SendEmailOptions;
  * <p>NOTE: Inherited classes may NOT have every method implemented. You should check the implementation of each Email
  * type and ensure that it has the features you require.
  */
-public abstract class Email {
+public abstract class EmailClient {
 
     public abstract List<Message> getPastMessages() throws EmailException;
 

--- a/src/main/java/org/patinanetwork/codebloom/common/email/client/codebloom/OfficialCodebloomEmailClient.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/email/client/codebloom/OfficialCodebloomEmailClient.java
@@ -9,7 +9,7 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import java.util.List;
 import java.util.Properties;
-import org.patinanetwork.codebloom.common.email.Email;
+import org.patinanetwork.codebloom.common.email.EmailClient;
 import org.patinanetwork.codebloom.common.email.Message;
 import org.patinanetwork.codebloom.common.email.error.EmailException;
 import org.patinanetwork.codebloom.common.email.options.SendEmailOptions;
@@ -22,14 +22,14 @@ import org.springframework.stereotype.Component;
  * <p>For example, we use this client to send emails to users who are trying to verify their school status.
  */
 @Component
-@EnableConfigurationProperties(OfficialCodebloomEmailProperties.class)
+@EnableConfigurationProperties(OfficialCodebloomEmailClientProperties.class)
 @Timed(value = "email.client.execution")
-public class OfficialCodebloomEmail extends Email {
+public class OfficialCodebloomEmailClient extends EmailClient {
 
-    private final OfficialCodebloomEmailProperties emailProperties;
+    private final OfficialCodebloomEmailClientProperties emailProperties;
     private Session session;
 
-    public OfficialCodebloomEmail(final OfficialCodebloomEmailProperties emailProperties) {
+    public OfficialCodebloomEmailClient(final OfficialCodebloomEmailClientProperties emailProperties) {
         this.emailProperties = emailProperties;
         final Properties properties = new Properties();
         properties.setProperty("mail.smtp.host", emailProperties.getHost());

--- a/src/main/java/org/patinanetwork/codebloom/common/email/client/codebloom/OfficialCodebloomEmailClientProperties.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/email/client/codebloom/OfficialCodebloomEmailClientProperties.java
@@ -3,7 +3,7 @@ package org.patinanetwork.codebloom.common.email.client.codebloom;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "codebloom.email")
-public class OfficialCodebloomEmailProperties {
+public class OfficialCodebloomEmailClientProperties {
 
     private String host;
     private String port;

--- a/src/main/java/org/patinanetwork/codebloom/common/email/client/github/GithubOAuthEmailClient.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/email/client/github/GithubOAuthEmailClient.java
@@ -10,7 +10,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import org.patinanetwork.codebloom.common.email.Email;
+import org.patinanetwork.codebloom.common.email.EmailClient;
 import org.patinanetwork.codebloom.common.email.Message;
 import org.patinanetwork.codebloom.common.email.error.EmailException;
 import org.patinanetwork.codebloom.common.email.options.SendEmailOptions;
@@ -19,18 +19,18 @@ import org.springframework.stereotype.Component;
 
 /** Provides read-only access to the Github email account in order to access the OAuth code. */
 @Component
-@EnableConfigurationProperties(GithubOAuthEmailProperties.class)
+@EnableConfigurationProperties(GithubOAuthEmailClientProperties.class)
 @Timed(value = "email.client.execution")
-public class GithubOAuthEmail extends Email {
+public class GithubOAuthEmailClient extends EmailClient {
 
-    private final GithubOAuthEmailProperties emailProperties;
+    private final GithubOAuthEmailClientProperties emailClientProperties;
     private static Session session;
 
-    public GithubOAuthEmail(final GithubOAuthEmailProperties emailProperties) {
-        this.emailProperties = emailProperties;
+    public GithubOAuthEmailClient(final GithubOAuthEmailClientProperties emailClientProperties) {
+        this.emailClientProperties = emailClientProperties;
         final Properties properties = new Properties();
-        properties.setProperty("mail.imap.host", emailProperties.getHost());
-        properties.setProperty("mail.imap.port", emailProperties.getPort());
+        properties.setProperty("mail.imap.host", emailClientProperties.getHost());
+        properties.setProperty("mail.imap.port", emailClientProperties.getPort());
         properties.setProperty("mail.imap.ssl.enable", "true");
         properties.setProperty("mail.imap.auth", "true");
         properties.setProperty("mail.store.protocol", "imap");
@@ -42,7 +42,10 @@ public class GithubOAuthEmail extends Email {
         try {
             final Store store = session.getStore("imap");
 
-            store.connect(emailProperties.getHost(), emailProperties.getUsername(), emailProperties.getPassword());
+            store.connect(
+                    emailClientProperties.getHost(),
+                    emailClientProperties.getUsername(),
+                    emailClientProperties.getPassword());
 
             final Folder emailFolder = store.getFolder("Inbox");
             emailFolder.open(Folder.READ_ONLY);
@@ -81,7 +84,7 @@ public class GithubOAuthEmail extends Email {
     @Override
     @Deprecated
     public void sendMessage(final SendEmailOptions sendEmailOptions) throws EmailException {
-        throw new UnsupportedOperationException("GithubOAuthEmail does not support sending messages.");
+        throw new UnsupportedOperationException("GithubOAuthEmailClient does not support sending messages.");
     }
 
     @Override
@@ -89,7 +92,10 @@ public class GithubOAuthEmail extends Email {
         try {
             final Store store = session.getStore("imap");
 
-            store.connect(emailProperties.getHost(), emailProperties.getUsername(), emailProperties.getPassword());
+            store.connect(
+                    emailClientProperties.getHost(),
+                    emailClientProperties.getUsername(),
+                    emailClientProperties.getPassword());
 
             final Folder emailFolder = store.getFolder("Inbox");
             emailFolder.open(Folder.READ_ONLY);

--- a/src/main/java/org/patinanetwork/codebloom/common/email/client/github/GithubOAuthEmailClientProperties.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/email/client/github/GithubOAuthEmailClientProperties.java
@@ -3,7 +3,7 @@ package org.patinanetwork.codebloom.common.email.client.github;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "github.email")
-public class GithubOAuthEmailProperties {
+public class GithubOAuthEmailClientProperties {
 
     private String host;
     private String port;

--- a/src/main/java/org/patinanetwork/codebloom/common/email/error/EmailException.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/email/error/EmailException.java
@@ -1,6 +1,6 @@
 package org.patinanetwork.codebloom.common.email.error;
 
-/** Base exception for {@link org.patinanetwork.codebloom.common.email.Email} */
+/** Base exception for {@link org.patinanetwork.codebloom.common.email.EmailClient} */
 public class EmailException extends Exception {
 
     public EmailException() {

--- a/src/main/java/org/patinanetwork/codebloom/common/email/template/ReactEmailTemplater.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/email/template/ReactEmailTemplater.java
@@ -2,7 +2,7 @@ package org.patinanetwork.codebloom.common.email.template;
 
 import java.io.IOException;
 
-public interface ReactEmailClient {
+public interface ReactEmailTemplater {
     /**
      * Load the generated HTML from ClassPathResources as a String then injects variables using Jsoup and renders HTML
      * as a string.

--- a/src/main/java/org/patinanetwork/codebloom/common/email/template/ReactEmailTemplaterImpl.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/email/template/ReactEmailTemplaterImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
 
 @Component
-public class ReactEmailClientImpl implements ReactEmailClient {
+public class ReactEmailTemplaterImpl implements ReactEmailTemplater {
 
     private String getHtmlAsString(final String path) throws IOException {
         ClassPathResource resource = new ClassPathResource(path);

--- a/src/main/java/org/patinanetwork/codebloom/playwright/PlaywrightClient.java
+++ b/src/main/java/org/patinanetwork/codebloom/playwright/PlaywrightClient.java
@@ -16,9 +16,9 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.patinanetwork.codebloom.common.db.models.auth.Auth;
 import org.patinanetwork.codebloom.common.db.models.usertag.Tag;
-import org.patinanetwork.codebloom.common.email.Email;
+import org.patinanetwork.codebloom.common.email.EmailClient;
 import org.patinanetwork.codebloom.common.email.Message;
-import org.patinanetwork.codebloom.common.email.client.github.GithubOAuthEmail;
+import org.patinanetwork.codebloom.common.email.client.github.GithubOAuthEmailClient;
 import org.patinanetwork.codebloom.common.url.ServerUrlUtils;
 import org.patinanetwork.codebloom.scheduled.auth.CodeExtractor;
 import org.springframework.stereotype.Component;
@@ -31,11 +31,11 @@ public class PlaywrightClient {
             "Mozilla/5.0 (Linux; U; Android 4.4.1; SAMSUNG SM-J210G Build/KTU84P) AppleWebKit/536.31 (KHTML, like Gecko) Chrome/48.0.2090.359 Mobile Safari/601.9";
 
     private final ServerUrlUtils serverUrlUtils;
-    private final Email email;
+    private final EmailClient emailClient;
 
-    public PlaywrightClient(final ServerUrlUtils serverUrlUtils, GithubOAuthEmail githubOAuthEmail) {
+    public PlaywrightClient(final ServerUrlUtils serverUrlUtils, GithubOAuthEmailClient githubOAuthEmailClient) {
         this.serverUrlUtils = serverUrlUtils;
-        this.email = githubOAuthEmail;
+        this.emailClient = githubOAuthEmailClient;
     }
 
     private <T> T withPage(final Function<Page, T> consumer) {
@@ -86,7 +86,7 @@ public class PlaywrightClient {
                 p.waitForTimeout(10000);
 
                 try {
-                    messages = email.getPastMessages();
+                    messages = emailClient.getPastMessages();
                 } catch (Exception e) {
                     log.info("Failed to retrieve past messages");
                     throw new RuntimeException("Failed to retrieve past messages", e);

--- a/src/test/java/org/patinanetwork/codebloom/api/auth/AuthControllerTest.java
+++ b/src/test/java/org/patinanetwork/codebloom/api/auth/AuthControllerTest.java
@@ -27,10 +27,10 @@ import org.patinanetwork.codebloom.common.db.models.user.User;
 import org.patinanetwork.codebloom.common.db.repos.session.SessionRepository;
 import org.patinanetwork.codebloom.common.db.repos.user.UserRepository;
 import org.patinanetwork.codebloom.common.db.repos.usertag.UserTagRepository;
-import org.patinanetwork.codebloom.common.email.client.codebloom.OfficialCodebloomEmail;
+import org.patinanetwork.codebloom.common.email.client.codebloom.OfficialCodebloomEmailClient;
 import org.patinanetwork.codebloom.common.email.error.EmailException;
 import org.patinanetwork.codebloom.common.email.options.SendEmailOptions;
-import org.patinanetwork.codebloom.common.email.template.ReactEmailClient;
+import org.patinanetwork.codebloom.common.email.template.ReactEmailTemplater;
 import org.patinanetwork.codebloom.common.jwt.JWTClient;
 import org.patinanetwork.codebloom.common.reporter.Reporter;
 import org.patinanetwork.codebloom.common.schools.magic.MagicLink;
@@ -50,11 +50,11 @@ public class AuthControllerTest {
     private final Protector protector = mock(Protector.class);
     private final JWTClient jwtClient = mock(JWTClient.class);
     private final UserRepository userRepository = mock(UserRepository.class);
-    private final OfficialCodebloomEmail emailClient = mock(OfficialCodebloomEmail.class);
+    private final OfficialCodebloomEmailClient emailClient = mock(OfficialCodebloomEmailClient.class);
     private final ServerUrlUtils serverUrlUtils = mock(ServerUrlUtils.class);
     private final UserTagRepository userTagRepository = mock(UserTagRepository.class);
     private final Reporter reporter = mock(Reporter.class);
-    private final ReactEmailClient reactEmailClient = mock(ReactEmailClient.class);
+    private final ReactEmailTemplater reactEmailTemplater = mock(ReactEmailTemplater.class);
     private final SimpleRedis<Long> simpleRedis = mock(SimpleRedis.class);
     private final SimpleRedisProvider simpleRedisProvider = mock(SimpleRedisProvider.class);
 
@@ -74,7 +74,7 @@ public class AuthControllerTest {
                 serverUrlUtils,
                 userTagRepository,
                 reporter,
-                reactEmailClient,
+                reactEmailTemplater,
                 simpleRedisProvider);
         this.faker = Faker.instance();
     }
@@ -284,7 +284,7 @@ public class AuthControllerTest {
         when(protector.validateSession(request)).thenReturn(authObj);
         when(jwtClient.encode(any(MagicLink.class), any(Duration.class))).thenReturn("mock-token");
         when(serverUrlUtils.getUrl()).thenReturn("http://localhost:8080");
-        when(reactEmailClient.schoolEmailTemplate(any())).thenReturn("<html>Template</html>");
+        when(reactEmailTemplater.schoolEmailTemplate(any())).thenReturn("<html>Template</html>");
         doThrow(new EmailException("Failed to send email")).when(emailClient).sendMessage(any(SendEmailOptions.class));
 
         ResponseStatusException exception =
@@ -311,7 +311,7 @@ public class AuthControllerTest {
         when(simpleRedis.containsKey(user.getId())).thenReturn(false);
         when(jwtClient.encode(any(MagicLink.class), any(Duration.class))).thenReturn("mock-token");
         when(serverUrlUtils.getUrl()).thenReturn("http://localhost:8080");
-        when(reactEmailClient.schoolEmailTemplate(any())).thenReturn("<html>Template</html>");
+        when(reactEmailTemplater.schoolEmailTemplate(any())).thenReturn("<html>Template</html>");
 
         var response = authController.enrollSchool(emailBody, request);
 

--- a/src/test/java/org/patinanetwork/codebloom/common/db/repos/BaseRepositoryTest.java
+++ b/src/test/java/org/patinanetwork/codebloom/common/db/repos/BaseRepositoryTest.java
@@ -1,7 +1,7 @@
 package org.patinanetwork.codebloom.common.db.repos;
 
-import org.patinanetwork.codebloom.common.email.client.codebloom.OfficialCodebloomEmail;
-import org.patinanetwork.codebloom.common.email.client.github.GithubOAuthEmail;
+import org.patinanetwork.codebloom.common.email.client.codebloom.OfficialCodebloomEmailClient;
+import org.patinanetwork.codebloom.common.email.client.github.GithubOAuthEmailClient;
 import org.patinanetwork.codebloom.jda.JDAClientManager;
 import org.patinanetwork.codebloom.jda.command.JDASlashCommandInitializer;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -20,8 +20,8 @@ public class BaseRepositoryTest {
     private JDASlashCommandInitializer jdaSlashCommandInitializer;
 
     @MockitoBean
-    private OfficialCodebloomEmail codebloomEmail;
+    private OfficialCodebloomEmailClient codebloomEmailClient;
 
     @MockitoBean
-    private GithubOAuthEmail githubOAuthEmail;
+    private GithubOAuthEmailClient githubOAuthEmailClient;
 }

--- a/src/test/java/org/patinanetwork/codebloom/common/email/TestEmailClients.java
+++ b/src/test/java/org/patinanetwork/codebloom/common/email/TestEmailClients.java
@@ -1,8 +1,8 @@
 package org.patinanetwork.codebloom.common.email;
 
 import org.junit.jupiter.api.Test;
-import org.patinanetwork.codebloom.common.email.client.codebloom.OfficialCodebloomEmail;
-import org.patinanetwork.codebloom.common.email.client.github.GithubOAuthEmail;
+import org.patinanetwork.codebloom.common.email.client.codebloom.OfficialCodebloomEmailClient;
+import org.patinanetwork.codebloom.common.email.client.github.GithubOAuthEmailClient;
 import org.patinanetwork.codebloom.common.email.error.EmailException;
 import org.patinanetwork.codebloom.config.NoJdaRequired;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,19 +11,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 public class TestEmailClients extends NoJdaRequired {
 
-    private final GithubOAuthEmail githubOAuthEmail;
-    private final OfficialCodebloomEmail officialCodebloomEmail;
+    private final GithubOAuthEmailClient githubOAuthEmailClient;
+    private final OfficialCodebloomEmailClient officialCodebloomEmailClient;
 
     @Autowired
     public TestEmailClients(
-            final GithubOAuthEmail githubOAuthEmail, final OfficialCodebloomEmail officialCodebloomEmail) {
-        this.githubOAuthEmail = githubOAuthEmail;
-        this.officialCodebloomEmail = officialCodebloomEmail;
+            final GithubOAuthEmailClient githubOAuthEmailClient,
+            final OfficialCodebloomEmailClient officialCodebloomEmailClient) {
+        this.githubOAuthEmailClient = githubOAuthEmailClient;
+        this.officialCodebloomEmailClient = officialCodebloomEmailClient;
     }
 
     @Test
     void testConnections() throws EmailException {
-        githubOAuthEmail.testConnection();
-        officialCodebloomEmail.testConnection();
+        githubOAuthEmailClient.testConnection();
+        officialCodebloomEmailClient.testConnection();
     }
 }

--- a/src/test/java/org/patinanetwork/codebloom/common/email/client/github/GithubOAuthEmailClientTest.java
+++ b/src/test/java/org/patinanetwork/codebloom/common/email/client/github/GithubOAuthEmailClientTest.java
@@ -1,0 +1,113 @@
+package org.patinanetwork.codebloom.common.email.client.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.mail.Folder;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import org.patinanetwork.codebloom.common.email.error.EmailException;
+import org.patinanetwork.codebloom.common.email.options.SendEmailOptions;
+
+class GithubOAuthEmailClientTest {
+
+    @Test
+    void testSendMessageThrowsUnsupportedOperationException() {
+        GithubOAuthEmailClientProperties properties = new GithubOAuthEmailClientProperties();
+        properties.setHost("imap.gmail.com");
+        properties.setPort("993");
+
+        GithubOAuthEmailClient client = new GithubOAuthEmailClient(properties);
+
+        SendEmailOptions options = SendEmailOptions.builder()
+                .recipientEmail("recipient@example.com")
+                .subject("Test")
+                .body("Test content")
+                .build();
+
+        assertThrows(UnsupportedOperationException.class, () -> client.sendMessage(options));
+    }
+
+    @Test
+    void testGetPastMessagesThrowsEmailException() {
+        GithubOAuthEmailClientProperties properties = new GithubOAuthEmailClientProperties();
+        properties.setHost("invalid.host.example");
+        properties.setPort("993");
+
+        GithubOAuthEmailClient client = new GithubOAuthEmailClient(properties);
+
+        EmailException exception = assertThrows(EmailException.class, client::getPastMessages);
+        assertEquals("Something went wrong when receiving past messages", exception.getMessage());
+    }
+
+    @Test
+    void testConnectionThrowsEmailException() {
+        GithubOAuthEmailClientProperties properties = new GithubOAuthEmailClientProperties();
+        properties.setHost("invalid.host.example");
+        properties.setPort("993");
+
+        GithubOAuthEmailClient client = new GithubOAuthEmailClient(properties);
+
+        EmailException exception = assertThrows(EmailException.class, client::testConnection);
+        assertEquals("Something went wrong when testing connection", exception.getMessage());
+    }
+
+    @Test
+    void testGetPastMessagesReadsTextPlainContent() throws Exception {
+        GithubOAuthEmailClientProperties properties = new GithubOAuthEmailClientProperties();
+        properties.setHost("imap.gmail.com");
+        properties.setPort("993");
+
+        Store mockStore = mock(Store.class);
+        Folder mockFolder = mock(Folder.class);
+        jakarta.mail.Message mockMessage = mock(jakarta.mail.Message.class);
+        Session mockSession = mock(Session.class);
+
+        when(mockMessage.isMimeType("text/plain")).thenReturn(true);
+        when(mockMessage.getInputStream()).thenReturn(new ByteArrayInputStream("test".getBytes()));
+        when(mockMessage.getSubject()).thenReturn("Subject");
+        when(mockMessage.getReceivedDate()).thenReturn(new Date());
+        when(mockFolder.getMessages(anyInt(), anyInt())).thenReturn(new jakarta.mail.Message[] {mockMessage});
+        when(mockFolder.getMessageCount()).thenReturn(1);
+        when(mockStore.getFolder("Inbox")).thenReturn(mockFolder);
+        when(mockSession.getStore("imap")).thenReturn(mockStore);
+
+        GithubOAuthEmailClient client = new GithubOAuthEmailClient(properties);
+        java.lang.reflect.Field sessionField = GithubOAuthEmailClient.class.getDeclaredField("session");
+        sessionField.setAccessible(true);
+        sessionField.set(client, mockSession);
+
+        assertEquals(1, client.getPastMessages().size());
+    }
+
+    @Test
+    void testGetPastMessagesCatchesException() throws Exception {
+        GithubOAuthEmailClientProperties properties = new GithubOAuthEmailClientProperties();
+        properties.setHost("imap.gmail.com");
+        properties.setPort("993");
+
+        Store mockStore = mock(Store.class);
+        Folder mockFolder = mock(Folder.class);
+        jakarta.mail.Message mockMessage = mock(jakarta.mail.Message.class);
+        Session mockSession = mock(Session.class);
+
+        when(mockMessage.isMimeType("text/plain")).thenThrow(new RuntimeException());
+        when(mockFolder.getMessages(anyInt(), anyInt())).thenReturn(new jakarta.mail.Message[] {mockMessage});
+        when(mockFolder.getMessageCount()).thenReturn(1);
+        when(mockStore.getFolder("Inbox")).thenReturn(mockFolder);
+        when(mockSession.getStore("imap")).thenReturn(mockStore);
+
+        GithubOAuthEmailClient client = new GithubOAuthEmailClient(properties);
+        java.lang.reflect.Field sessionField = GithubOAuthEmailClient.class.getDeclaredField("session");
+        sessionField.setAccessible(true);
+        sessionField.set(client, mockSession);
+
+        assertEquals(0, client.getPastMessages().size());
+    }
+}

--- a/src/test/java/org/patinanetwork/codebloom/common/email/template/ReactEmailTemplaterTest.java
+++ b/src/test/java/org/patinanetwork/codebloom/common/email/template/ReactEmailTemplaterTest.java
@@ -9,17 +9,17 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Test;
 
-class ReactEmailClientTest {
+class ReactEmailTemplaterTest {
 
     @Test
     void exampleTemplateTest() throws IOException {
-        ReactEmailClient client = new ReactEmailClientImpl();
+        ReactEmailTemplater templater = new ReactEmailTemplaterImpl();
 
         String recipientName = "Example";
         String verifyUrl = "https://example.com";
         String supportEmail = "codebloom@patinanetwork.org";
 
-        String renderedHtml = client.createExampleTemplate(recipientName, verifyUrl, supportEmail);
+        String renderedHtml = templater.createExampleTemplate(recipientName, verifyUrl, supportEmail);
 
         Document doc = Jsoup.parse(renderedHtml);
 
@@ -46,10 +46,10 @@ class ReactEmailClientTest {
 
     @Test
     void emailTest() throws IOException {
-        ReactEmailClient client = new ReactEmailClientImpl();
+        ReactEmailTemplater templater = new ReactEmailTemplaterImpl();
         String verifyUrl = "https://example.com/example/href";
 
-        String renderedHtml = client.schoolEmailTemplate(verifyUrl);
+        String renderedHtml = templater.schoolEmailTemplate(verifyUrl);
 
         Document doc = Jsoup.parse(renderedHtml);
 


### PR DESCRIPTION
## [791](https://codebloom.notion.site/Rename-Email-Client-File-Names-3087c85563aa80a1b533e845d43dbf45)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes
- Updated OfficialCodebloomEmail to OfficialCodebloomEmailClient and GithubOAuthEmail⁩ to GithubOAuthEmail⁩Client and ReactEmailClient to ReactEmail
- Updated ReactEmailClient to ReactEmailTemplater
- Updated variables as well
- Updated Email to EmailClient
- Added GithubOAuthEmailClientTest to meet test coverage minimum
## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->
- No changes besides naming of files.

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
- No changes besides naming of files.
