### PR TITLE
793: Remove old text section from Discord embed

### DIFF
--- a/src/main/java/org/patinanetwork/codebloom/common/components/DiscordClubManager.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/components/DiscordClubManager.java
@@ -102,8 +102,6 @@ public class DiscordClubManager {
 
                 %s
 
-                To view the rest of the members, visit the website or check out the image embedded in this message!
-
                 The new leaderboard just started, so best of luck to everyone!
 
                 View the full leaderboard for %s users at %s/leaderboard/%s?%s=true
@@ -236,8 +234,6 @@ public class DiscordClubManager {
             %s
 
             %s
-
-            To view the rest of the members, visit the website or check out the image embedded in this message!
 
             Just as a reminder, there's %d day(s), %d hour(s), and %d minute(s) left until the leaderboard closes, so keep grinding!
 


### PR DESCRIPTION
## [793](https://codebloom.notion.site/Remove-old-text-section-from-Discord-embed-3097c85563aa80e2af7cfe83c543198e)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<img width="607" height="482" alt="image" src="https://github.com/user-attachments/assets/700ecba3-0f8e-4486-8f4e-7ff096402d0d" />
<img width="622" height="418" alt="image" src="https://github.com/user-attachments/assets/ffbbed30-13fe-4a07-a5ba-87b84ae8c7ed" />

### Staging

Not necessary, basic text change.
