### PR TITLE
929: Changed author size test

### DIFF
--- a/src/test/java/org/patinanetwork/codebloom/api/ApiControllerTest.java
+++ b/src/test/java/org/patinanetwork/codebloom/api/ApiControllerTest.java
@@ -53,6 +53,6 @@ public class ApiControllerTest {
         assertTrue(serverMetadataObject.getName() != null, "Testing server name is not null");
         List<String> authors = serverMetadataObject.getAuthors();
         assertTrue(authors != null, "Testing authors list is not null");
-        assertTrue(authors.size() == 6, "Testing length of authors, expected 6.");
+        assertTrue(authors.size() > 0, "Testing length of authors.");
     }
 }


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

Since new Codebloom devs need to add their names to the /api endpoint, the assertion has been changed to check if authors.size() in the api controller is > 0 rather than strictly 6

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
