### PR TITLE
551: Fix Leaderboard Card Ordering On Mobile View

### DIFF
--- a/js/src/app/dashboard/Dashboard.page.tsx
+++ b/js/src/app/dashboard/Dashboard.page.tsx
@@ -63,30 +63,26 @@ export default function DashboardPage() {
             : <RefreshSubmissions schoolRegistered={schoolRegistered} />}
           </Center>
           <Flex direction={smallPhone ? "row" : "column"} gap={"md"}>
-            {smallPhone ?
-              <>
-                <Flex direction={"column"} flex={1}>
-                  <ProblemOfTheDay />
-                </Flex>
+            {(() => {
+              const leaderboardCard = (
                 <Flex direction={"column"} flex={1}>
                   <DashboardLeaderboard
                     userId={data.user.id}
                     userTags={data.user.tags}
                   />
                 </Flex>
-              </>
-            : <>
-                <Flex direction={"column"} flex={1}>
-                  <DashboardLeaderboard
-                    userId={data.user.id}
-                    userTags={data.user.tags}
-                  />
-                </Flex>
+              );
+              const problemOfTheDayCard = (
                 <Flex direction={"column"} flex={1}>
                   <ProblemOfTheDay />
                 </Flex>
-              </>
-            }
+              );
+              const orderedComponents =
+                smallPhone ?
+                  [problemOfTheDayCard, leaderboardCard]
+                : [leaderboardCard, problemOfTheDayCard];
+              return <>{orderedComponents}</>;
+            })()}
             <Flex direction={"column"} flex={1}>
               <RecentSubmissions userId={data.user.id} />
             </Flex>

--- a/js/src/app/dashboard/Dashboard.page.tsx
+++ b/js/src/app/dashboard/Dashboard.page.tsx
@@ -63,15 +63,30 @@ export default function DashboardPage() {
             : <RefreshSubmissions schoolRegistered={schoolRegistered} />}
           </Center>
           <Flex direction={smallPhone ? "row" : "column"} gap={"md"}>
-            <Flex direction={"column"} flex={1}>
-              <ProblemOfTheDay />
-            </Flex>
-            <Flex direction={"column"} flex={1}>
-              <DashboardLeaderboard
-                userId={data.user.id}
-                userTags={data.user.tags}
-              />
-            </Flex>
+            {smallPhone ?
+              <>
+                <Flex direction={"column"} flex={1}>
+                  <ProblemOfTheDay />
+                </Flex>
+                <Flex direction={"column"} flex={1}>
+                  <DashboardLeaderboard
+                    userId={data.user.id}
+                    userTags={data.user.tags}
+                  />
+                </Flex>
+              </>
+            : <>
+                <Flex direction={"column"} flex={1}>
+                  <DashboardLeaderboard
+                    userId={data.user.id}
+                    userTags={data.user.tags}
+                  />
+                </Flex>
+                <Flex direction={"column"} flex={1}>
+                  <ProblemOfTheDay />
+                </Flex>
+              </>
+            }
             <Flex direction={"column"} flex={1}>
               <RecentSubmissions userId={data.user.id} />
             </Flex>

--- a/js/src/app/dashboard/_components/ProblemOfTheDay/ProblemOfTheDay.tsx
+++ b/js/src/app/dashboard/_components/ProblemOfTheDay/ProblemOfTheDay.tsx
@@ -40,7 +40,10 @@ export default function ProblemOfTheDay() {
   const json = data.payload;
 
   return (
-    <CodebloomCard miw={"31vw"} mih={"63vh"}>
+    <CodebloomCard
+      miw={{ base: "31vw", md: "31vw" }}
+      mih={{ base: "auto", md: "63vh" }}
+    >
       <Center>
         <Title style={{ textAlign: "center" }} order={3}>
           Problem of the day

--- a/js/src/app/dashboard/_components/ProblemOfTheDay/ProblemOfTheDay.tsx
+++ b/js/src/app/dashboard/_components/ProblemOfTheDay/ProblemOfTheDay.tsx
@@ -40,10 +40,7 @@ export default function ProblemOfTheDay() {
   const json = data.payload;
 
   return (
-    <CodebloomCard
-      miw={{ base: "31vw", md: "31vw" }}
-      mih={{ base: "auto", md: "63vh" }}
-    >
+    <CodebloomCard miw="31vw" mih={{ base: "auto", md: "63vh" }}>
       <Center>
         <Title style={{ textAlign: "center" }} order={3}>
           Problem of the day


### PR DESCRIPTION
## [551](https://codebloom.notion.site/Fix-Leaderboard-Card-Ordering-On-Mobile-View-2d77c85563aa80c48f27c2aff55f126f)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

- Moved the POTD under the leaderboard for mobile view
- Fixed the spacing of the POTD box for mobile view

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<img width="510" height="747" alt="Screenshot 2026-04-14 at 11 54 27 PM" src="https://github.com/user-attachments/assets/cf6bb2ad-b8de-40e2-bdaf-04edcee16ac3" />
<img width="506" height="738" alt="Screenshot 2026-04-14 at 11 54 18 PM" src="https://github.com/user-attachments/assets/c5f356a9-b793-4850-9ae2-ca9f4d7760c4" />

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
