### PR TITLE
901: center mobile navigation title and login button

### DIFF
--- a/js/src/components/ui/header/Header.tsx
+++ b/js/src/components/ui/header/Header.tsx
@@ -112,8 +112,19 @@ export default function Header() {
         withCloseButton={false}
         size="50%"
         title="Navigation"
+        styles={{
+          header: {
+            justifyContent: "center",
+          },
+          title: {
+            textAlign: "center",
+            fontWeight: 700,
+            fontSize: "var(--mantine-font-size-lg)",
+            marginBottom: "var(--mantine-spacing-xs)",
+          },
+        }}
       >
-        <Flex direction="column" align="center" gap="xs">
+        <Flex direction="column" align="center" gap="xs" w="100%">
           {navButtons.map(({ to, label }) => (
             <Button
               component={Link}
@@ -127,7 +138,9 @@ export default function Header() {
               {label}
             </Button>
           ))}
-          {renderButton("w-full")}
+          <Flex justify="center" w="100%" mt="xs">
+            {renderButton("full-width")}
+          </Flex>
         </Flex>
       </Drawer>
     </>


### PR DESCRIPTION
## [901](https://codebloom.notion.site/Fix-Mobile-Menu-View-3387c85563aa80ee9892d789bf2d400e)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes
Centered the mobile navigation drawer title and login button. Verified in mobile view.

## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<img width="823" height="794" alt="image" src="https://github.com/user-attachments/assets/ccb70cf1-1ee8-47fd-b7b9-8b874df59beb" />
<!-- Screenshots go here -->

### Staging
<img width="1308" height="695" alt="image" src="https://github.com/user-attachments/assets/f65ebc5c-c463-4da1-9b9e-2c9729e1fb4b" />
<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
