### PR TITLE
240: Create new filters param on previous leaderboard endpoint

### DIFF
--- a/src/main/java/org/patinanetwork/codebloom/api/leaderboard/LeaderboardController.java
+++ b/src/main/java/org/patinanetwork/codebloom/api/leaderboard/LeaderboardController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.patinanetwork.codebloom.common.components.LeaderboardManager;
 import org.patinanetwork.codebloom.common.db.models.leaderboard.Leaderboard;
 import org.patinanetwork.codebloom.common.db.models.user.UserWithScore;
@@ -93,6 +94,9 @@ public class LeaderboardController {
             })
     public ResponseEntity<ApiResponder<Page<Indexed<UserWithScoreDto>>>> getLeaderboardUsersById(
             @PathVariable final String leaderboardId,
+            @Parameter(description = "Comma-separated list of active filters.", example = "nyu,hunter,globalIndex")
+                    @RequestParam(required = false)
+                    final Set<String> filters,
             @Parameter(description = "Page index", example = "1") @RequestParam(required = false, defaultValue = "1")
                     final int page,
             @Parameter(description = "Page size (maximum of " + MAX_LEADERBOARD_PAGE_SIZE)
@@ -133,29 +137,30 @@ public class LeaderboardController {
                     final boolean globalIndex,
             final HttpServletRequest request) {
         FakeLag.sleep(800);
-
         final int parsedPageSize = Math.min(pageSize, MAX_LEADERBOARD_PAGE_SIZE);
+        final Set<String> activeFilters = filters != null ? filters : Set.of();
+        final boolean useFilters = !activeFilters.isEmpty();
+        final boolean globalIndexNew = useFilters ? activeFilters.contains("globalIndex") : globalIndex;
 
-        LeaderboardFilterOptions options = LeaderboardFilterOptions.builder()
+        final LeaderboardFilterOptions options = LeaderboardFilterOptions.builder()
                 .page(page)
                 .pageSize(parsedPageSize)
                 .query(query)
-                .patina(patina)
-                .hunter(hunter)
-                .nyu(nyu)
-                .baruch(baruch)
-                .rpi(rpi)
-                .gwc(gwc)
-                .sbu(sbu)
-                .ccny(ccny)
-                .columbia(columbia)
-                .cornell(cornell)
-                .bmcc(bmcc)
-                .mhcplusplus(mhcplusplus)
+                .patina(useFilters ? activeFilters.contains("patina") : patina)
+                .hunter(useFilters ? activeFilters.contains("hunter") : hunter)
+                .nyu(useFilters ? activeFilters.contains("nyu") : nyu)
+                .baruch(useFilters ? activeFilters.contains("baruch") : baruch)
+                .rpi(useFilters ? activeFilters.contains("rpi") : rpi)
+                .gwc(useFilters ? activeFilters.contains("gwc") : gwc)
+                .sbu(useFilters ? activeFilters.contains("sbu") : sbu)
+                .ccny(useFilters ? activeFilters.contains("ccny") : ccny)
+                .columbia(useFilters ? activeFilters.contains("columbia") : columbia)
+                .cornell(useFilters ? activeFilters.contains("cornell") : cornell)
+                .bmcc(useFilters ? activeFilters.contains("bmcc") : bmcc)
+                .mhcplusplus(useFilters ? activeFilters.contains("mhcplusplus") : mhcplusplus)
                 .build();
-
         Page<Indexed<UserWithScoreDto>> createdPage =
-                leaderboardManager.getLeaderboardUsers(leaderboardId, options, globalIndex);
+                leaderboardManager.getLeaderboardUsers(leaderboardId, options, globalIndexNew);
 
         return ResponseEntity.ok().body(ApiResponder.success("All leaderboards found!", createdPage));
     }

--- a/src/test/java/org/patinanetwork/codebloom/api/leaderboard/LeaderboardControllerTest.java
+++ b/src/test/java/org/patinanetwork/codebloom/api/leaderboard/LeaderboardControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -54,6 +55,7 @@ public class LeaderboardControllerTest {
     void testGetLeaderboardUsersByIdMhcPlusPlus() {
         leaderboardController.getLeaderboardUsersById(
                 LEADERBOARD_ID,
+                null,
                 PAGE,
                 PAGE_SIZE,
                 "",
@@ -135,6 +137,7 @@ public class LeaderboardControllerTest {
     void capsPageSize() {
         leaderboardController.getLeaderboardUsersById(
                 LEADERBOARD_ID,
+                null,
                 1,
                 999,
                 "",
@@ -164,6 +167,7 @@ public class LeaderboardControllerTest {
     void passesAllFilters() {
         leaderboardController.getLeaderboardUsersById(
                 LEADERBOARD_ID,
+                null,
                 2,
                 10,
                 "tahmid",
@@ -201,6 +205,96 @@ public class LeaderboardControllerTest {
         assertTrue(opts.isCornell());
         assertTrue(opts.isBmcc());
         assertTrue(opts.isMhcplusplus());
+    }
+
+    @Test
+    @DisplayName("uses filters Set when provided, ignoring individual boolean params")
+    void usesFiltersSetWhenProvided() {
+        leaderboardController.getLeaderboardUsersById(
+                LEADERBOARD_ID,
+                Set.of("nyu", "hunter"),
+                PAGE,
+                PAGE_SIZE,
+                "",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                null);
+
+        ArgumentCaptor<LeaderboardFilterOptions> captor = ArgumentCaptor.forClass(LeaderboardFilterOptions.class);
+        verify(leaderboardManager).getLeaderboardUsers(eq(LEADERBOARD_ID), captor.capture(), eq(false));
+        var opts = captor.getValue();
+        assertTrue(opts.isNyu());
+        assertTrue(opts.isHunter());
+        assertFalse(opts.isPatina());
+    }
+
+    @Test
+    @DisplayName("sets globalIndex from filters Set when it contains globalIndex")
+    void setsGlobalIndexFromFiltersSet() {
+        leaderboardController.getLeaderboardUsersById(
+                LEADERBOARD_ID,
+                Set.of("nyu", "globalIndex"),
+                PAGE,
+                PAGE_SIZE,
+                "",
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                null);
+
+        ArgumentCaptor<LeaderboardFilterOptions> captor = ArgumentCaptor.forClass(LeaderboardFilterOptions.class);
+        verify(leaderboardManager).getLeaderboardUsers(eq(LEADERBOARD_ID), captor.capture(), eq(true));
+        assertTrue(captor.getValue().isNyu());
+    }
+
+    @Test
+    @DisplayName("falls back to boolean params when filters Set is empty")
+    void fallsBackToBooleansWhenFiltersEmpty() {
+        leaderboardController.getLeaderboardUsersById(
+                LEADERBOARD_ID,
+                Set.of(),
+                PAGE,
+                PAGE_SIZE,
+                "",
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                null);
+
+        ArgumentCaptor<LeaderboardFilterOptions> captor = ArgumentCaptor.forClass(LeaderboardFilterOptions.class);
+        verify(leaderboardManager).getLeaderboardUsers(eq(LEADERBOARD_ID), captor.capture(), eq(false));
+        assertTrue(captor.getValue().isPatina());
     }
 
     @Test


### PR DESCRIPTION
## [240](https://codebloom.notion.site/Create-new-filters-param-on-previous-leaderboard-endpoint-24c7c85563aa800da818ef68dc697bb9)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes
Added filters parameter (a set of strings) that store the items that belong in the leaderboard url. Added an if else statement for when filters is empty or null. When it's empty or null it goes back to previous url. 
## Checklist before review

- [x] I have done a thorough self-review of the PR
- [x] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [x] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [x] All tests have passed
- [x] I have successfully deployed this PR to staging
- [x] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev
Current: 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/c795fb67-9587-4398-84d6-ce151dde9387" />


New:  
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/3f8c28e3-1947-41cb-a152-c344a8e30f36" />

### Staging

