### PR TITLE
947: Created Submit and Forfeit buttons

### DIFF
--- a/js/src/app/duel/current/ForfeitButton.tsx
+++ b/js/src/app/duel/current/ForfeitButton.tsx
@@ -1,0 +1,37 @@
+import { Button, Group, Modal, Text } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+
+export default function ForfeitButton() {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  const handleConfirm = () => {
+    close();
+  };
+
+  return (
+    <>
+      <Button color="red" onClick={open}>
+        Forfeit
+      </Button>
+      <Modal
+        opened={opened}
+        onClose={close}
+        withCloseButton={false}
+        centered
+        size="sm"
+      >
+        <Text mb="md" ta="center">
+          Are you sure you want to Forfeit?
+        </Text>
+        <Group justify="center">
+          <Button color="red" onClick={close}>
+            ✕
+          </Button>
+          <Button color="green" onClick={handleConfirm}>
+            ✓
+          </Button>
+        </Group>
+      </Modal>
+    </>
+  );
+}

--- a/js/src/app/duel/current/SubmitButton.tsx
+++ b/js/src/app/duel/current/SubmitButton.tsx
@@ -1,0 +1,13 @@
+import { Button } from "@mantine/core";
+
+export default function SubmitButton() {
+  const handleSubmit = () => {
+    console.log("Test");
+  };
+
+  return (
+    <Button color="green" onClick={handleSubmit}>
+      Submit
+    </Button>
+  );
+}


### PR DESCRIPTION
## [947](https://codebloom.notion.site/Duel-Submit-Forfeit-3407c85563aa80d0a948f694b370cdd6)
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes
Created Submit and Forfeit Buttons. Added SubmitButton (logs to console for now) and added ForfeitButton which opens confirmation modal.
## Checklist before review

- [ ] I have done a thorough self-review of the PR
- [ ] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [ ] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [ ] All tests have passed
- [ ] I have successfully deployed this PR to staging
- [ ] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev
<img width="1309" height="318" alt="Screenshot 2026-04-23 at 7 01 22 PM" src="https://github.com/user-attachments/assets/c11a6fbc-e9ed-4e67-922a-1333252147e4" />
<img width="1313" height="490" alt="Screenshot 2026-04-23 at 7 00 42 PM" src="https://github.com/user-attachments/assets/ad326b9b-aab1-4183-987c-cafe94a0cdf5" />
<img width="788" height="483" alt="Screenshot 2026-04-23 at 7 05 50 PM" src="https://github.com/user-attachments/assets/8daf602f-e433-4e9a-9121-4e4367053a36" />

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
