### PR TITLE
chore: delete CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-* @Patina-Network/codebloom
-
-CODEOWNERS @Patina-Network/admin
-.github/ @Patina-Network/cicd


### PR DESCRIPTION
CODEOWNERS-based review has been migrated into repository ruleset required reviewers, managed centrally in `platform-infra`. This file is no longer used, so it is being removed.

Context: Patina-Network/platform-infra#216