### PR TITLE
Remove actuator basic auth (will be replaced by cluster)

### DIFF
--- a/src/main/java/org/patinanetwork/codebloom/api/auth/security/SecurityActuatorProperties.java
+++ b/src/main/java/org/patinanetwork/codebloom/api/auth/security/SecurityActuatorProperties.java
@@ -1,6 +1,0 @@
-package org.patinanetwork.codebloom.api.auth.security;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-@ConfigurationProperties(prefix = "security.actuator")
-public record SecurityActuatorProperties(String username, String password) {}

--- a/src/main/java/org/patinanetwork/codebloom/api/auth/security/SecurityConfig.java
+++ b/src/main/java/org/patinanetwork/codebloom/api/auth/security/SecurityConfig.java
@@ -1,6 +1,5 @@
 package org.patinanetwork.codebloom.api.auth.security;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -8,9 +7,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
@@ -20,7 +16,6 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
  * @see <a href= "https://github.com/tahminator/codebloom/tree/main/docs/auth.md">Authentication Documentation</a>
  */
 @Configuration
-@EnableConfigurationProperties(SecurityActuatorProperties.class)
 @EnableWebSecurity
 public class SecurityConfig {
 
@@ -28,29 +23,6 @@ public class SecurityConfig {
 
     public SecurityConfig(final AuthenticationSuccessHandler customAuthenticationSuccessHandler) {
         this.customAuthenticationSuccessHandler = customAuthenticationSuccessHandler;
-    }
-
-    @Bean
-    UserDetailsService userDetailsService(SecurityActuatorProperties props) {
-        return new InMemoryUserDetailsManager(User.withUsername(props.username())
-                .password("{noop}" + props.password())
-                .roles("ACTUATOR")
-                .build());
-    }
-
-    /**
-     * Security filter chain for actuator endpoints with HTTP Basic authentication. This needs to be processed first
-     * (Order 1) to prevent OAuth from being applied.
-     */
-    @Bean
-    @Order(1)
-    public SecurityFilterChain actuatorSecurityFilterChain(final HttpSecurity http) throws Exception {
-        http.securityMatcher("/actuator/**")
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.anyRequest().hasRole("ACTUATOR"))
-                .httpBasic(basic -> {});
-
-        return http.build();
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,11 +106,6 @@ management:
     prometheus:
       enabled: true
 
-security:
-  actuator:
-    username: ${ACTUATOR_USERNAME}
-    password: ${ACTUATOR_PASSWORD}
-
 secret:
   key: ${SECRET_KEY}
 


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

we now enforce actuator protections via ingress rules here:
https://github.com/Patina-Network/k8s-manifests/blob/main/base/production/codebloom/ingress.yaml#L27-L50

they are protected by a `basic-auth` middleware, defined here:
https://github.com/Patina-Network/k8s-manifests/tree/main/base/production/middleware/basic-auth

## Checklist before review

- [ ] I have done a thorough self-review of the PR
- [ ] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [ ] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [ ] All tests have passed
- [ ] I have successfully deployed this PR to staging
- [ ] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

# Staging

<img width="720" height="413" alt="image" src="https://github.com/user-attachments/assets/3462dd61-9a89-4e61-ac4a-1211e725188c" />
<img width="705" height="267" alt="image" src="https://github.com/user-attachments/assets/a425aee7-6378-4750-af23-b385f9821cad" />

